### PR TITLE
Fix HTTPS healthcheck status detection

### DIFF
--- a/api/home-box-landing/HomeBoxLanding.Api.Tests/Features/HealthCheck/HealthCheckServiceTests.cs
+++ b/api/home-box-landing/HomeBoxLanding.Api.Tests/Features/HealthCheck/HealthCheckServiceTests.cs
@@ -1,0 +1,103 @@
+using System.Net;
+using System.Net.Http;
+using HomeBoxLanding.Api.Features.HealthCheck;
+using Microsoft.Extensions.Http;
+using NUnit.Framework;
+
+namespace HomeBoxLanding.Api.Tests.Features.HealthCheck;
+
+[TestFixture]
+public class HealthCheckServiceTests
+{
+    [Test]
+    public async Task PerformHealthCheck_UsesHttpsForSecureTargets()
+    {
+        var handler = new RecordingHandler(HttpStatusCode.OK);
+        var service = CreateService(handler);
+
+        var response = await service.PerformHealthCheck("example.com:443", true);
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+        Assert.That(handler.Request!.RequestUri!.AbsoluteUri, Is.EqualTo("https://example.com:443/"));
+    }
+
+    [Test]
+    public async Task PerformHealthCheck_UsesHttpForInsecureTargets()
+    {
+        var handler = new RecordingHandler(HttpStatusCode.OK);
+        var service = CreateService(handler);
+
+        var response = await service.PerformHealthCheck("example.com:80", false);
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+        Assert.That(handler.Request!.RequestUri!.AbsoluteUri, Is.EqualTo("http://example.com:80/"));
+    }
+
+    [Test]
+    public async Task PerformHealthCheck_UsesDefaultPortWhenOneIsNotProvided()
+    {
+        var handler = new RecordingHandler(HttpStatusCode.OK);
+        var service = CreateService(handler);
+
+        var response = await service.PerformHealthCheck("example.com", true);
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+        Assert.That(handler.Request!.RequestUri!.AbsoluteUri, Is.EqualTo("https://example.com/"));
+    }
+
+    [Test]
+    public async Task PerformHealthCheck_ReturnsServerErrorWhenTargetCannotBeReached()
+    {
+        var handler = new RecordingHandler(new HttpRequestException("certificate validation failed"));
+        var service = CreateService(handler);
+
+        var response = await service.PerformHealthCheck("example.com:443", true);
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.InternalServerError));
+    }
+
+    private static HealthCheckService CreateService(HttpMessageHandler handler)
+    {
+        var httpClient = new HttpClient(handler);
+        var factory = new TestHttpClientFactory(httpClient);
+        return new HealthCheckService(factory);
+    }
+
+    private sealed class TestHttpClientFactory(HttpClient client) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => client;
+    }
+
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode? _statusCode;
+        private readonly Exception? _exception;
+
+        public RecordingHandler(HttpStatusCode statusCode)
+        {
+            _statusCode = statusCode;
+        }
+
+        public RecordingHandler(Exception exception)
+        {
+            _exception = exception;
+        }
+
+        public HttpRequestMessage? Request { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Request = request;
+
+            if (_exception is not null)
+            {
+                throw _exception;
+            }
+
+            return Task.FromResult(new HttpResponseMessage(_statusCode!.Value)
+            {
+                RequestMessage = request,
+            });
+        }
+    }
+}

--- a/api/home-box-landing/HomeBoxLanding.Api.Tests/Features/HealthCheck/HealthCheckServiceTests.cs
+++ b/api/home-box-landing/HomeBoxLanding.Api.Tests/Features/HealthCheck/HealthCheckServiceTests.cs
@@ -15,10 +15,10 @@ public class HealthCheckServiceTests
         var handler = new RecordingHandler(HttpStatusCode.OK);
         var service = CreateService(handler);
 
-        var response = await service.PerformHealthCheck("example.com:443", true);
+        var response = await service.PerformHealthCheck("example.com:8443", true);
 
         Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
-        Assert.That(handler.Request!.RequestUri!.AbsoluteUri, Is.EqualTo("https://example.com:443/"));
+        Assert.That(handler.Request!.RequestUri!.AbsoluteUri, Is.EqualTo("https://example.com:8443/"));
     }
 
     [Test]
@@ -27,10 +27,10 @@ public class HealthCheckServiceTests
         var handler = new RecordingHandler(HttpStatusCode.OK);
         var service = CreateService(handler);
 
-        var response = await service.PerformHealthCheck("example.com:80", false);
+        var response = await service.PerformHealthCheck("example.com:8080", false);
 
         Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
-        Assert.That(handler.Request!.RequestUri!.AbsoluteUri, Is.EqualTo("http://example.com:80/"));
+        Assert.That(handler.Request!.RequestUri!.AbsoluteUri, Is.EqualTo("http://example.com:8080/"));
     }
 
     [Test]

--- a/api/home-box-landing/HomeBoxLanding.Api/Features/HealthCheck/HealthCheckService.cs
+++ b/api/home-box-landing/HomeBoxLanding.Api/Features/HealthCheck/HealthCheckService.cs
@@ -6,11 +6,13 @@ namespace HomeBoxLanding.Api.Features.HealthCheck;
 
 public class HealthCheckService
 {
+    private const string AcceptHeader = "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7";
     private readonly HttpClient _httpClient;
 
     public HealthCheckService(IHttpClientFactory httpClientFactory)
     {
         _httpClient = httpClientFactory.CreateClient("IgnoreSslClient");
+        _httpClient.Timeout = TimeSpan.FromSeconds(10);
     }
 
     public async Task<HealthCheckResponse> PerformHealthCheck(string url, bool isSecure)
@@ -26,22 +28,18 @@ public class HealthCheckService
                 DurationInMilliseconds = 10,
             };
         }
-        
-        var prefix = isSecure ? "https" : "http";
-        var stopwatch = new Stopwatch();
+
+        var stopwatch = Stopwatch.StartNew();
 
         try
         {
-            _httpClient.Timeout = TimeSpan.FromSeconds(10);
-            _httpClient.DefaultRequestHeaders.Add("Accept","text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7");
-            _httpClient.DefaultRequestHeaders.Add("Accept-Language","en-GB,en-US;q=0.9,en;q=0.8");
-            _httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("Mozilla/5.0 (Windows NT 10.0; Win64; x64)");
+            var target = BuildTargetUri(url, isSecure);
+            using var request = new HttpRequestMessage(HttpMethod.Get, target);
+            request.Headers.Accept.ParseAdd(AcceptHeader);
+            request.Headers.AcceptLanguage.ParseAdd("en-GB,en-US;q=0.9,en;q=0.8");
+            request.Headers.UserAgent.ParseAdd("Mozilla/5.0 (Windows NT 10.0; Win64; x64)");
 
-            stopwatch.Start();
-            var result = await _httpClient.GetAsync($"{prefix}://{url}");
-            stopwatch.Stop();
-            
-            await result.Content.ReadAsStringAsync();
+            using var result = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
 
             return new HealthCheckResponse
             {
@@ -52,18 +50,6 @@ public class HealthCheckService
         }
         catch (Exception e)
         {
-            stopwatch.Stop();
-            
-            if (isSecure)
-            {
-                return new HealthCheckResponse
-                {
-                    StatusCode = HttpStatusCode.BadRequest,
-                    StatusDescription = e.Message,
-                    DurationInMilliseconds = stopwatch.ElapsedMilliseconds,
-                };
-            }
-
             return new HealthCheckResponse
             {
                 StatusCode = HttpStatusCode.InternalServerError,
@@ -71,5 +57,33 @@ public class HealthCheckService
                 DurationInMilliseconds = stopwatch.ElapsedMilliseconds,
             };
         }
+        finally
+        {
+            stopwatch.Stop();
+        }
+    }
+
+    private static Uri BuildTargetUri(string url, bool isSecure)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            throw new ArgumentException("A host is required for a health check.", nameof(url));
+        }
+
+        var scheme = isSecure ? Uri.UriSchemeHttps : Uri.UriSchemeHttp;
+        var address = url.Trim();
+
+        if (!address.Contains("://", StringComparison.Ordinal))
+        {
+            address = $"{scheme}://{address}";
+        }
+
+        if (!Uri.TryCreate(address, UriKind.Absolute, out var target) ||
+            !string.Equals(target.Scheme, scheme, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new UriFormatException($"The health check target '{url}' is invalid.");
+        }
+
+        return target;
     }
 }

--- a/api/home-box-landing/HomeBoxLanding.Api/Program.cs
+++ b/api/home-box-landing/HomeBoxLanding.Api/Program.cs
@@ -29,6 +29,7 @@ builder.Services.AddMemoryCache();
 
 builder.Services.AddHttpClient("IgnoreSslClient").ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
 {
+    CheckCertificateRevocationList = false,
     ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
 });
 

--- a/src/components/url-health-checker/url-health-checker.component.ts
+++ b/src/components/url-health-checker/url-health-checker.component.ts
@@ -1,5 +1,5 @@
 import { Component, EventEmitter, Input, OnDestroy, OnInit, Output, signal, WritableSignal } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { first, Subject, takeUntil } from 'rxjs';
 import { environment } from '../../environments/environment';
 
@@ -42,9 +42,14 @@ export class UrlHealthCheckerComponent implements OnInit, OnDestroy {
 
     public ngOnInit(): void {
 
-        this.isSecure.set(this.url.startsWith('https://'));
+        this.isSecure.set(this.url.toLowerCase().startsWith('https://'));
 
-            this._httpClient.get(`${environment.apiBaseUrl}/api/healthcheck?url=${this.host}:${this.port}&isSecure=${this.isSecure()}`, {})
+        const target = this.port > 0 ? `${this.host}:${this.port}` : this.host;
+        const params = new HttpParams()
+            .set('url', target)
+            .set('isSecure', this.isSecure());
+
+        this._httpClient.get(`${environment.apiBaseUrl}/api/healthcheck`, { params })
             .pipe(
                 first(),
                 takeUntil(this._destroy)


### PR DESCRIPTION
## Summary

- build healthcheck targets as valid HTTP/HTTPS URIs, including default ports
- preserve HTTPS healthchecks for services using self-signed or otherwise untrusted certificates
- report connection, DNS, URI, and SSL failures consistently as down instead of a misleading warning
- add regression coverage for HTTP, HTTPS, default ports, and unreachable targets

## Validation

- `npm run build` passed (existing Sass deprecation and bundle-budget warnings remain)
- `npm run lint` passed
- `git diff --check` passed
- Backend tests were added but could not run locally because the .NET SDK and Docker daemon were unavailable
- Existing frontend test commands are incompatible with the current Angular 22 test configuration

This pull request was created by an AI agent (OpenHands) on behalf of the user.
