### PR TITLE
Keep local HTTPS healthchecks as warnings

### DIFF
--- a/api/home-box-landing/HomeBoxLanding.Api.Tests/Features/HealthCheck/HealthCheckServiceTests.cs
+++ b/api/home-box-landing/HomeBoxLanding.Api.Tests/Features/HealthCheck/HealthCheckServiceTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http;
+using System.Security.Authentication;
 using HomeBoxLanding.Api.Features.HealthCheck;
 using Microsoft.Extensions.Http;
 using NUnit.Framework;
@@ -46,12 +47,25 @@ public class HealthCheckServiceTests
     }
 
     [Test]
-    public async Task PerformHealthCheck_ReturnsServerErrorWhenTargetCannotBeReached()
+    public async Task PerformHealthCheck_ReturnsWarningWhenSslConnectionCannotBeEstablished()
     {
-        var handler = new RecordingHandler(new HttpRequestException("certificate validation failed"));
+        var handler = new RecordingHandler(new HttpRequestException(
+            "The SSL connection could not be established, see inner exception.",
+            new AuthenticationException("The certificate is not trusted.")));
         var service = CreateService(handler);
 
-        var response = await service.PerformHealthCheck("example.com:443", true);
+        var response = await service.PerformHealthCheck("home.lan:443", true);
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
+    }
+
+    [Test]
+    public async Task PerformHealthCheck_ReturnsServerErrorWhenTargetCannotBeReached()
+    {
+        var handler = new RecordingHandler(new HttpRequestException("connection refused"));
+        var service = CreateService(handler);
+
+        var response = await service.PerformHealthCheck("home.lan:443", true);
 
         Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.InternalServerError));
     }

--- a/api/home-box-landing/HomeBoxLanding.Api/Features/HealthCheck/HealthCheckService.cs
+++ b/api/home-box-landing/HomeBoxLanding.Api/Features/HealthCheck/HealthCheckService.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Net;
+using System.Security.Authentication;
 using HomeBoxLanding.Api.Features.HealthCheck.Types;
 
 namespace HomeBoxLanding.Api.Features.HealthCheck;
@@ -52,7 +53,7 @@ public class HealthCheckService
         {
             return new HealthCheckResponse
             {
-                StatusCode = HttpStatusCode.InternalServerError,
+                StatusCode = IsSslFailure(e) ? HttpStatusCode.BadRequest : HttpStatusCode.InternalServerError,
                 StatusDescription = e.Message,
                 DurationInMilliseconds = stopwatch.ElapsedMilliseconds,
             };
@@ -61,6 +62,22 @@ public class HealthCheckService
         {
             stopwatch.Stop();
         }
+    }
+
+    private static bool IsSslFailure(Exception exception)
+    {
+        for (var current = exception; current is not null; current = current.InnerException)
+        {
+            if (current is AuthenticationException ||
+                current.Message.Contains("SSL connection", StringComparison.OrdinalIgnoreCase) ||
+                current.Message.Contains("TLS", StringComparison.OrdinalIgnoreCase) ||
+                current.Message.Contains("certificate", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static Uri BuildTargetUri(string url, bool isSecure)


### PR DESCRIPTION
## Summary

- preserve the orange warning state for SSL/TLS negotiation failures, including local `home.lan` services with certificates that cannot be validated
- keep DNS, connection-refused, timeout, and other unreachable-target failures red
- add regression coverage for both SSL failures and genuine connectivity failures

## Validation

- `git diff --check` passed
- Backend tests are configured to run in CI; the local environment does not have the .NET SDK

This pull request was created by an AI agent (OpenHands) on behalf of the user.
