### PR TITLE
Add loading skeletons for link widgets

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -81,7 +81,7 @@
                           ],
                           "scripts": [],
                           "polyfills": [
-                            "src/polyfills.ts"
+                            "zone.js"
                           ]
                         }
                     },
@@ -115,9 +115,6 @@
                         "coverageReporters": [
                           "html",
                           "text-summary"
-                        ],
-                        "setupFiles": [
-                          "src/test.ts"
                         ],
                         "buildTarget": ":build:testing",
                         "runner": "vitest"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
     "format": "npm run lint-fix",
-    "test-ci": "ng test --browsers=ChromeHeadless --no-watch --code-coverage",
+    "test-ci": "ng test --no-watch --coverage",
     "lint": "eslint src",
     "lint-fix": "eslint src --fix"
   },
@@ -43,6 +43,7 @@
     "@types/jasmine": "~6.0.0",
     "@typescript-eslint/eslint-plugin": "^8.65.0",
     "@typescript-eslint/parser": "^8.65.0",
+    "@vitest/coverage-v8": "^4.1.10",
     "eslint": "^10.8.0",
     "eslint-plugin-import": "^2.32.0",
     "globals": "^17.8.0",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -66,6 +66,7 @@ import {
 } from '../components/custom-link/custom-details/uptime-kuma-details/uptime-kuma-details.component';
 import { UptimeKumaService } from '../services/uptime-kuma-service/uptime-kuma.service';
 import { UptimeKumaRepository } from '../services/uptime-kuma-service/uptime-kuma-repository';
+import { WidgetSkeletonComponent } from '../components/widget-skeleton/widget-skeleton.component';
 
 @NgModule({
     declarations: [
@@ -98,7 +99,8 @@ import { UptimeKumaRepository } from '../services/uptime-kuma-service/uptime-kum
         FolderComponent,
         AddFolderComponent,
         NotepadPageComponent,
-        UptimeKumaDetailsComponent
+        UptimeKumaDetailsComponent,
+        WidgetSkeletonComponent
     ],
     bootstrap: [AppComponent],
     imports: [BrowserModule,

--- a/src/components/custom-link/custom-details/lidarr-details/lidarr-details.component.html
+++ b/src/components/custom-link/custom-details/lidarr-details/lidarr-details.component.html
@@ -1,4 +1,6 @@
-@if (activity()) {
+@if (isLoading()) {
+  <widget-skeleton></widget-skeleton>
+} @else if (activity()) {
   <div class="lidarr__details">
     <div class="o-grid o-grid--static">
       <div class="o-grid__col o-grid__col--equal">

--- a/src/components/custom-link/custom-details/lidarr-details/lidarr-details.component.ts
+++ b/src/components/custom-link/custom-details/lidarr-details/lidarr-details.component.ts
@@ -18,6 +18,7 @@ export class LidarrDetailsComponent implements OnInit, OnDestroy {
     public activity: WritableSignal<ILidarrActivity | null> = signal<ILidarrActivity | null>(null);
     public readonly Object = Object;
     public groupedHealth: any | null = null;
+    public isLoading: WritableSignal<boolean> = signal<boolean>(true);
 
     private readonly _destroy: Subject<void> = new Subject();
     private readonly _lidarrService: LidarrService;
@@ -29,10 +30,14 @@ export class LidarrDetailsComponent implements OnInit, OnDestroy {
     public ngOnInit() {
         this._lidarrService.getActivity()
             .pipe(takeUntil(this._destroy))
-            .subscribe((activity: ILidarrActivity) => {
-                this.activity.set(activity);
-                // @ts-ignore
-                this.groupedHealth = Object.groupBy(this.activity()!.health, (x: any) => x.type);
+            .subscribe({
+                next: (activity: ILidarrActivity) => {
+                    this.activity.set(activity);
+                    // @ts-ignore
+                    this.groupedHealth = Object.groupBy(this.activity()!.health, (x: any) => x.type);
+                    this.isLoading.set(false);
+                },
+                error: () => this.isLoading.set(false)
             });
 
         this._lidarrService.activity
@@ -42,6 +47,7 @@ export class LidarrDetailsComponent implements OnInit, OnDestroy {
                 this.activity.set(activity);
                 // @ts-ignore
                 this.groupedHealth = Object.groupBy(this.activity()!.health, (x: any) => x.type);
+                this.isLoading.set(false);
             });
 
         this._lidarrService.ngOnInit();

--- a/src/components/custom-link/custom-details/pihole-details/pihole-details.component.html
+++ b/src/components/custom-link/custom-details/pihole-details/pihole-details.component.html
@@ -1,4 +1,6 @@
-@if (activity()) {
+@if (isLoading()) {
+  <widget-skeleton></widget-skeleton>
+} @else if (activity()) {
   <div class="pihole__details">
     <div class="o-grid o-grid--static">
       <div class="o-grid__col o-grid__col--equal">

--- a/src/components/custom-link/custom-details/pihole-details/pihole-details.component.ts
+++ b/src/components/custom-link/custom-details/pihole-details/pihole-details.component.ts
@@ -17,6 +17,7 @@ export class PiholeDetailsComponent implements OnInit, OnDestroy {
 
     public activity: WritableSignal<IPiHoleActivity | null> = signal<IPiHoleActivity | null>(null);
     public formattedQueriesTotal: WritableSignal<string | null> = signal<string | null>(null);
+    public isLoading: WritableSignal<boolean> = signal<boolean>(true);
 
     private readonly _destroy: Subject<void> = new Subject();
     private readonly _piholeService: PiHoleService;
@@ -28,19 +29,25 @@ export class PiholeDetailsComponent implements OnInit, OnDestroy {
     public ngOnInit() {
         this._piholeService.getActivity(this.item?.identifier!)
             .pipe(takeUntil(this._destroy))
-            .subscribe((activity: IPiHoleActivity) => {
-                this.activity.set(activity);
-                const formattedTotal = new Intl.NumberFormat('en-GB');
-                this.formattedQueriesTotal.set(formattedTotal.format(this.activity()!.queriesToday));
+            .subscribe({
+                next: (activity: IPiHoleActivity) => {
+                    this.activity.set(activity);
+                    const formattedTotal = new Intl.NumberFormat('en-GB');
+                    this.formattedQueriesTotal.set(formattedTotal.format(this.activity()!.queriesToday));
+                    this.isLoading.set(false);
+                },
+                error: () => this.isLoading.set(false)
             });
 
         this._piholeService.activities
             .asObservable()
             .pipe(takeUntil(this._destroy))
             .subscribe((response: Array<IPiHoleActivity>) => {
-                this.activity.set(response.find((x) => x.identifier === this.item?.identifier) ?? null);
+                const activity = response.find((x) => x.identifier === this.item?.identifier) ?? null;
+                this.activity.set(activity);
                 const formattedTotal = new Intl.NumberFormat('en-GB');
-                this.formattedQueriesTotal.set(formattedTotal.format(this.activity()!.queriesToday ?? 0));
+                this.formattedQueriesTotal.set(formattedTotal.format(activity?.queriesToday ?? 0));
+                this.isLoading.set(false);
             });
 
         this._piholeService.ngOnInit();

--- a/src/components/custom-link/custom-details/plex-details/plex-details.component.html
+++ b/src/components/custom-link/custom-details/plex-details/plex-details.component.html
@@ -1,4 +1,6 @@
-@if (plexSessions().length > 0) {
+@if (isLoading()) {
+  <widget-skeleton variant="progress"></widget-skeleton>
+} @else if (plexSessions().length > 0) {
   <div class="plex__details">
     @for (session of plexSessions(); track session) {
       <div>

--- a/src/components/custom-link/custom-details/plex-details/plex-details.component.ts
+++ b/src/components/custom-link/custom-details/plex-details/plex-details.component.ts
@@ -16,6 +16,7 @@ export class PlexDetailsComponent implements OnInit, OnDestroy {
     public item: ILink | null = null;
 
     public plexSessions: WritableSignal<Array<IPlexSession>> = signal<Array<IPlexSession>>([]);
+    public isLoading: WritableSignal<boolean> = signal<boolean>(true);
 
     private readonly _destroy: Subject<void> = new Subject();
     private readonly _plexService: PlexService;
@@ -27,8 +28,12 @@ export class PlexDetailsComponent implements OnInit, OnDestroy {
     public ngOnInit() {
         this._plexService.getActivity()
             .pipe(takeUntil(this._destroy))
-            .subscribe((response: Array<IPlexSession>) => {
-                this.plexSessions.set(response);
+            .subscribe({
+                next: (response: Array<IPlexSession>) => {
+                    this.plexSessions.set(response);
+                    this.isLoading.set(false);
+                },
+                error: () => this.isLoading.set(false)
             });
 
         this._plexService.sessions
@@ -36,6 +41,7 @@ export class PlexDetailsComponent implements OnInit, OnDestroy {
             .pipe(takeUntil(this._destroy))
             .subscribe((response: Array<IPlexSession>) => {
                 this.plexSessions.set(response);
+                this.isLoading.set(false);
             });
 
         setInterval(() => {

--- a/src/components/custom-link/custom-details/radarr-details/radarr-details.component.html
+++ b/src/components/custom-link/custom-details/radarr-details/radarr-details.component.html
@@ -1,4 +1,6 @@
-@if (activity()) {
+@if (isLoading()) {
+  <widget-skeleton></widget-skeleton>
+} @else if (activity()) {
   <div class="radarr__details">
     <div class="o-grid o-grid--static">
       <div class="o-grid__col o-grid__col--equal">

--- a/src/components/custom-link/custom-details/radarr-details/radarr-details.component.ts
+++ b/src/components/custom-link/custom-details/radarr-details/radarr-details.component.ts
@@ -18,6 +18,7 @@ export class RadarrDetailsComponent implements OnInit, OnDestroy {
     public activity: WritableSignal<IRadarrActivity | null> = signal<IRadarrActivity | null>(null);
     public readonly Object = Object;
     public groupedHealth: any | null = null;
+    public isLoading: WritableSignal<boolean> = signal<boolean>(true);
 
     private readonly _destroy: Subject<void> = new Subject();
     private readonly _radarrService: RadarrService;
@@ -29,10 +30,14 @@ export class RadarrDetailsComponent implements OnInit, OnDestroy {
     public ngOnInit() {
         this._radarrService.getActivity()
             .pipe(takeUntil(this._destroy))
-            .subscribe((activity: IRadarrActivity) => {
-                this.activity.set(activity);
-                // @ts-ignore
-                this.groupedHealth = Object.groupBy(this.activity()!.health, (x: any) => x.type);
+            .subscribe({
+                next: (activity: IRadarrActivity) => {
+                    this.activity.set(activity);
+                    // @ts-ignore
+                    this.groupedHealth = Object.groupBy(this.activity()!.health, (x: any) => x.type);
+                    this.isLoading.set(false);
+                },
+                error: () => this.isLoading.set(false)
             });
 
         this._radarrService.activity
@@ -42,6 +47,7 @@ export class RadarrDetailsComponent implements OnInit, OnDestroy {
                 this.activity.set(activity);
                 // @ts-ignore
                 this.groupedHealth = Object.groupBy(this.activity()!.health, (x: any) => x.type);
+                this.isLoading.set(false);
             });
 
         this._radarrService.ngOnInit();

--- a/src/components/custom-link/custom-details/readarr-details/readarr-details.component.html
+++ b/src/components/custom-link/custom-details/readarr-details/readarr-details.component.html
@@ -1,4 +1,6 @@
-@if (activity()) {
+@if (isLoading()) {
+  <widget-skeleton></widget-skeleton>
+} @else if (activity()) {
   <div class="lidarr__details">
     <div class="o-grid o-grid--static">
       <div class="o-grid__col o-grid__col--equal">

--- a/src/components/custom-link/custom-details/readarr-details/readarr-details.component.ts
+++ b/src/components/custom-link/custom-details/readarr-details/readarr-details.component.ts
@@ -18,6 +18,7 @@ export class ReadarrDetailsComponent implements OnInit, OnDestroy {
     public activity: WritableSignal<IReadarrActivity | null> = signal<IReadarrActivity | null>(null);
     public readonly Object = Object;
     public groupedHealth: any | null = null;
+    public isLoading: WritableSignal<boolean> = signal<boolean>(true);
 
     private readonly _destroy: Subject<void> = new Subject();
     private readonly _readarrService: ReadarrService;
@@ -29,10 +30,14 @@ export class ReadarrDetailsComponent implements OnInit, OnDestroy {
     public ngOnInit() {
         this._readarrService.getActivity()
             .pipe(takeUntil(this._destroy))
-            .subscribe((activity: IReadarrActivity) => {
-                this.activity.set(activity);
-                // @ts-ignore
-                this.groupedHealth = Object.groupBy(this.activity()!.health, (x: any) => x.type);
+            .subscribe({
+                next: (activity: IReadarrActivity) => {
+                    this.activity.set(activity);
+                    // @ts-ignore
+                    this.groupedHealth = Object.groupBy(this.activity()!.health, (x: any) => x.type);
+                    this.isLoading.set(false);
+                },
+                error: () => this.isLoading.set(false)
             });
 
         this._readarrService.activity
@@ -42,6 +47,7 @@ export class ReadarrDetailsComponent implements OnInit, OnDestroy {
                 this.activity.set(activity);
                 // @ts-ignore
                 this.groupedHealth = Object.groupBy(this.activity()!.health, (x: any) => x.type);
+                this.isLoading.set(false);
             });
 
         this._readarrService.ngOnInit();

--- a/src/components/custom-link/custom-details/sonarr-details/sonarr-details.component.html
+++ b/src/components/custom-link/custom-details/sonarr-details/sonarr-details.component.html
@@ -1,4 +1,6 @@
-@if (activity()) {
+@if (isLoading()) {
+  <widget-skeleton></widget-skeleton>
+} @else if (activity()) {
   <div class="radarr__details">
     <div class="o-grid o-grid--static">
       <div class="o-grid__col o-grid__col--equal">

--- a/src/components/custom-link/custom-details/sonarr-details/sonarr-details.component.ts
+++ b/src/components/custom-link/custom-details/sonarr-details/sonarr-details.component.ts
@@ -18,6 +18,7 @@ export class SonarrDetailsComponent implements OnInit, OnDestroy {
     public activity: WritableSignal<ISonarrActivity | null> = signal<ISonarrActivity | null>(null);
     public readonly Object = Object;
     public groupedHealth: any | null = null;
+    public isLoading: WritableSignal<boolean> = signal<boolean>(true);
 
     private readonly _destroy: Subject<void> = new Subject();
     private readonly _sonarrService: SonarrService;
@@ -29,10 +30,14 @@ export class SonarrDetailsComponent implements OnInit, OnDestroy {
     public ngOnInit() {
         this._sonarrService.getActivity()
             .pipe(takeUntil(this._destroy))
-            .subscribe((activity: ISonarrActivity) => {
-                this.activity.set(activity);
-                // @ts-ignore
-                this.groupedHealth = Object.groupBy(this.activity()!.health, (x: any) => x.type);
+            .subscribe({
+                next: (activity: ISonarrActivity) => {
+                    this.activity.set(activity);
+                    // @ts-ignore
+                    this.groupedHealth = Object.groupBy(this.activity()!.health, (x: any) => x.type);
+                    this.isLoading.set(false);
+                },
+                error: () => this.isLoading.set(false)
             });
 
         this._sonarrService.activity
@@ -42,6 +47,7 @@ export class SonarrDetailsComponent implements OnInit, OnDestroy {
                 this.activity.set(activity);
                 // @ts-ignore
                 this.groupedHealth = Object.groupBy(this.activity()!.health, (x: any) => x.type);
+                this.isLoading.set(false);
             });
 
         this._sonarrService.ngOnInit();

--- a/src/components/custom-link/custom-details/uptime-kuma-details/uptime-kuma-details.component.html
+++ b/src/components/custom-link/custom-details/uptime-kuma-details/uptime-kuma-details.component.html
@@ -1,4 +1,6 @@
-@if (activity()) {
+@if (isLoading()) {
+  <widget-skeleton></widget-skeleton>
+} @else if (activity()) {
   <div class="pihole__details">
     <div class="o-grid o-grid--static">
       <div class="o-grid__col o-grid__col--equal">

--- a/src/components/custom-link/custom-details/uptime-kuma-details/uptime-kuma-details.component.ts
+++ b/src/components/custom-link/custom-details/uptime-kuma-details/uptime-kuma-details.component.ts
@@ -19,6 +19,7 @@ export class UptimeKumaDetailsComponent implements OnInit, OnDestroy {
     public item: ILink | null = null;
 
     public activity: WritableSignal<IUptimeKumaActivity | null> = signal<IUptimeKumaActivity | null>(null);
+    public isLoading: WritableSignal<boolean> = signal<boolean>(true);
 
     private readonly _destroy: Subject<void> = new Subject();
     private readonly _uptimeKumaService: UptimeKumaService;
@@ -30,8 +31,12 @@ export class UptimeKumaDetailsComponent implements OnInit, OnDestroy {
     public ngOnInit() {
         this._uptimeKumaService.getActivity(this.item?.identifier!)
             .pipe(takeUntil(this._destroy))
-            .subscribe((activity: IUptimeKumaActivity) => {
-                this.activity.set(activity);
+            .subscribe({
+                next: (activity: IUptimeKumaActivity) => {
+                    this.activity.set(activity);
+                    this.isLoading.set(false);
+                },
+                error: () => this.isLoading.set(false)
             });
 
         this._uptimeKumaService.activities
@@ -39,6 +44,7 @@ export class UptimeKumaDetailsComponent implements OnInit, OnDestroy {
             .pipe(takeUntil(this._destroy))
             .subscribe((response: Array<IUptimeKumaActivity>) => {
                 this.activity.set(response.length > 0 ? response[0] : null);
+                this.isLoading.set(false);
             });
 
         this._uptimeKumaService.ngOnInit();

--- a/src/components/widget-skeleton/widget-skeleton.component.html
+++ b/src/components/widget-skeleton/widget-skeleton.component.html
@@ -1,0 +1,15 @@
+<div class="widget-skeleton" [class.widget-skeleton--progress]="variant === 'progress'" role="status" aria-label="Loading widget">
+    @if (variant === 'stats') {
+        @for (stat of [0, 1, 2]; track stat) {
+            <div class="widget-skeleton__stat">
+                <span class="widget-skeleton__line widget-skeleton__line--value"></span>
+                <span class="widget-skeleton__line widget-skeleton__line--label"></span>
+            </div>
+        }
+    } @else {
+        <div class="widget-skeleton__progress">
+            <span class="widget-skeleton__line widget-skeleton__line--progress"></span>
+            <span class="widget-skeleton__line widget-skeleton__line--text"></span>
+        </div>
+    }
+</div>

--- a/src/components/widget-skeleton/widget-skeleton.component.scss
+++ b/src/components/widget-skeleton/widget-skeleton.component.scss
@@ -1,0 +1,79 @@
+@import "../../styles/utility/variables";
+
+.widget-skeleton {
+    display: flex;
+    gap: 5px;
+    min-height: 77px;
+    padding: 15px;
+    border-radius: $border-radius;
+
+    &--progress {
+        display: block;
+        min-height: 67px;
+    }
+
+    &__stat {
+        display: flex;
+        flex: 1 1 0;
+        min-width: 0;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 7px;
+        min-height: 47px;
+        padding: 0 10px 5px;
+        border: 1px solid rgba(0, 0, 0, 0.35);
+        border-radius: $border-radius;
+        background-color: rgba(0, 0, 0, 0.25);
+    }
+
+    &__progress {
+        padding-top: 5px;
+    }
+
+    &__line {
+        display: block;
+        max-width: 100%;
+        border-radius: $border-radius;
+        background: linear-gradient(90deg, rgba(255, 255, 255, 0.08) 25%, rgba(255, 255, 255, 0.2) 50%, rgba(255, 255, 255, 0.08) 75%);
+        background-size: 200% 100%;
+        animation: widget-skeleton-shimmer 1.5s ease-in-out infinite;
+
+        &--value {
+            width: 38px;
+            height: 20px;
+        }
+
+        &--label {
+            width: 42px;
+            height: 8px;
+        }
+
+        &--progress {
+            width: 100%;
+            height: 5px;
+        }
+
+        &--text {
+            width: 65%;
+            height: 12px;
+            margin: 6px auto 0;
+        }
+    }
+}
+
+@keyframes widget-skeleton-shimmer {
+    0% {
+        background-position: 200% 0;
+    }
+
+    100% {
+        background-position: -200% 0;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .widget-skeleton__line {
+        animation: none;
+    }
+}

--- a/src/components/widget-skeleton/widget-skeleton.component.ts
+++ b/src/components/widget-skeleton/widget-skeleton.component.ts
@@ -1,0 +1,15 @@
+import { Component, Input } from '@angular/core';
+
+type WidgetSkeletonVariant = 'stats' | 'progress';
+
+@Component({
+    selector: 'widget-skeleton',
+    templateUrl: './widget-skeleton.component.html',
+    styleUrls: ['./widget-skeleton.component.scss'],
+    standalone: false
+})
+export class WidgetSkeletonComponent {
+
+    @Input()
+    public variant: WidgetSkeletonVariant = 'stats';
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -500,6 +500,11 @@
     "@babel/helper-string-parser" "^8.0.0"
     "@babel/helper-validator-identifier" "^8.0.4"
 
+"@bcoe/v8-coverage@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz#bbe12dca5b4ef983a0d0af4b07b9bc90ea0ababa"
+  integrity sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==
+
 "@bramus/specificity@^2.4.2":
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/@bramus/specificity/-/specificity-2.4.2.tgz#aa8db8eb173fdee7324f82284833106adeecc648"
@@ -983,7 +988,7 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz#6912b00d2c631c0d15ce1a7ab57cd657f2a8f8ba"
   integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
 
-"@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.28":
+"@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.28", "@jridgewell/trace-mapping@^0.3.31":
   version "0.3.31"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz#db15d6781c931f3a251a3dac39501c98a6082fd0"
   integrity sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==
@@ -1773,6 +1778,22 @@
   resolved "https://registry.yarnpkg.com/@vitejs/plugin-basic-ssl/-/plugin-basic-ssl-2.3.0.tgz#f505b1c197d8cb4fd6e213a78847574ecc51e2f9"
   integrity sha512-bdyo8rB3NnQbikdMpHaML9Z1OZPBu6fFOBo+OtxsBlvMJtysWskmBcnbIDhUqgC8tcxNv/a+BcV5U+2nQMm1OQ==
 
+"@vitest/coverage-v8@^4.1.10":
+  version "4.1.10"
+  resolved "https://registry.yarnpkg.com/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz#037cd5e7ea8a2f448f4c2e10db1411c2b0c927bd"
+  integrity sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==
+  dependencies:
+    "@bcoe/v8-coverage" "^1.0.2"
+    "@vitest/utils" "4.1.10"
+    ast-v8-to-istanbul "^1.0.0"
+    istanbul-lib-coverage "^3.2.2"
+    istanbul-lib-report "^3.0.1"
+    istanbul-reports "^3.2.0"
+    magicast "^0.5.2"
+    obug "^2.1.1"
+    std-env "^4.0.0-rc.1"
+    tinyrainbow "^3.1.0"
+
 "@vitest/expect@4.1.10":
   version "4.1.10"
   resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-4.1.10.tgz#799c06fc44bb0cf7e2784137b627c5cc173285d4"
@@ -2000,6 +2021,15 @@ assertion-error@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-2.0.1.tgz#f641a196b335690b1070bf00b6e7593fec190bf7"
   integrity sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==
+
+ast-v8-to-istanbul@^1.0.0:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.5.tgz#708baeb6f5c879226d112a341ffa821c43881d2d"
+  integrity sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==
+  dependencies:
+    "@jridgewell/trace-mapping" "^0.3.31"
+    estree-walker "^3.0.3"
+    js-tokens "^10.0.0"
 
 async-function@^1.0.0:
   version "1.0.0"
@@ -3720,7 +3750,7 @@ istanbul-lib-coverage@^2.0.5:
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz#675f0ab69503fad4b1d849f736baaca803344f49"
   integrity sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==
 
-istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.0:
+istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.0, istanbul-lib-coverage@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz#2d166c4b0644d43a39f04bf6c2edd1e585f31756"
   integrity sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==
@@ -3747,7 +3777,7 @@ istanbul-lib-instrument@^6.0.3:
     istanbul-lib-coverage "^3.2.0"
     semver "^7.5.4"
 
-istanbul-lib-report@^3.0.0:
+istanbul-lib-report@^3.0.0, istanbul-lib-report@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz#908305bac9a5bd175ac6a74489eafd0fc2445a7d"
   integrity sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==
@@ -3776,7 +3806,7 @@ istanbul-lib-source-maps@^4.0.1:
     istanbul-lib-coverage "^3.0.0"
     source-map "^0.6.1"
 
-istanbul-reports@^3.0.2, istanbul-reports@^3.0.5:
+istanbul-reports@^3.0.2, istanbul-reports@^3.0.5, istanbul-reports@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-3.2.0.tgz#cb4535162b5784aa623cee21a7252cf2c807ac93"
   integrity sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==
@@ -4157,6 +4187,15 @@ magic-string@^0.30.21:
   integrity sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==
   dependencies:
     "@jridgewell/sourcemap-codec" "^1.5.5"
+
+magicast@^0.5.2:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/magicast/-/magicast-0.5.4.tgz#bbe38dfd6037670057f33abf22b8aa79d5e99d0a"
+  integrity sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==
+  dependencies:
+    "@babel/parser" "^7.29.7"
+    "@babel/types" "^7.29.7"
+    source-map-js "^1.2.1"
 
 make-dir@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
## Summary

- add reusable stats-card and progress-row loading skeletons for additional link widgets
- reserve widget space while async data loads to prevent layout shifts
- handle successful and failed widget requests without leaving skeletons stuck
- update the Angular/Vitest CI test command for Angular 22 and add V8 coverage support

## Validation

- `yarn lint`
- `yarn build`
- `yarn test-ci` — 2 tests passed with V8 coverage

The build still reports existing Sass deprecation warnings and the existing initial bundle budget warning.

This pull request was created by an AI agent (OpenHands) on behalf of the user.