### PR TITLE
Fix tablet folder and link label overflow

### DIFF
--- a/src/components/custom-link/custom-link.component.html
+++ b/src/components/custom-link/custom-link.component.html
@@ -3,10 +3,11 @@
         <a [href]="item!.url">
             <div class="link__content">
                 <div class="o-grid o-grid--static">
-                    <div class="o-grid__col">
+                    <div class="o-grid__col link__name">
                         @if (showIcon()) {
                             <img [src]="item!.iconUrl" alt="{{ item!.name }} Logo" (error)="handleIconError()">
-                        } {{ item!.name }}
+                        }
+                        <span class="link__label">{{ item!.name }}</span>
                     </div>
                     @if (isEditModeEnabled()) {
                         <div class="o-grid__col o-grid__col--fixed u-ml-1 remove-link-wrapper">

--- a/src/components/custom-link/custom-link.component.scss
+++ b/src/components/custom-link/custom-link.component.scss
@@ -69,6 +69,23 @@
         }
     }
 
+    &__name {
+        @media(min-width: $mobile-width) and (max-width: $tablet-width) {
+            display: flex;
+            align-items: center;
+            min-width: 0;
+        }
+    }
+
+    &__label {
+        @media(min-width: $mobile-width) and (max-width: $tablet-width) {
+            min-width: 0;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+    }
+
     .remove-link-wrapper {
         display: none;
     }

--- a/src/components/folder/folder.component.html
+++ b/src/components/folder/folder.component.html
@@ -9,8 +9,8 @@
             <div class="o-grid__col o-grid__col--fixed">
                 <div class="folder__icon"><i class="{{ folder!.icon }}"></i></div>
             </div>
-            <div class="o-grid__col">
-                {{ folder!.name }}
+            <div class="o-grid__col folder__name">
+                <span class="folder__label">{{ folder!.name }}</span>
                 <span class="folder__count">{{ folder!.links.length }}</span>
             </div>
             @if (folder!.links.length > 0) {

--- a/src/components/folder/folder.component.scss
+++ b/src/components/folder/folder.component.scss
@@ -36,12 +36,31 @@
         text-align: center;
     }
 
+    &__name {
+        @media(min-width: $mobile-width) and (max-width: $tablet-width) {
+            display: flex;
+            align-items: center;
+            min-width: 0;
+        }
+    }
+
+    &__label {
+        @media(min-width: $mobile-width) and (max-width: $tablet-width) {
+            min-width: 0;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+    }
+
     &__count {
+        flex: 0 0 auto;
         font-size: 0.75rem;
         padding: 2px 8px;
         margin-left: 8px;
         border-radius: 10px;
         background-color: rgba(255, 255, 255, 0.15);
+        white-space: nowrap;
     }
 
     // Two fixed rows filling column by column, so the dots stay compact as a folder grows.


### PR DESCRIPTION
## Summary

- Keep folder names on one line on tablet layouts.
- Truncate long folder and link labels with an ellipsis between their fixed controls.
- Scope the behavior to tablet widths from 768px through 992px.

## Validation

- `yarn lint`
- `yarn build`
- `yarn test --no-watch`

The build passes with existing Sass deprecation and bundle-budget warnings.

_This pull request was created by an AI agent (OpenHands) on behalf of the user._
