### PR TITLE
Add Angular and .NET regression tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,8 +47,8 @@ jobs:
       - name: Install dependencies
         run: yarn --frozen-lockfile --prefer-offline
 
-      # - name: Test FE
-      #   run: npm run test-ci
+      - name: Test FE
+        run: npm run test-ci
 
 
   lint-fe:

--- a/api/home-box-landing/HomeBoxLanding.Api.Tests/Features/Columns/ColumnMapperTests.cs
+++ b/api/home-box-landing/HomeBoxLanding.Api.Tests/Features/Columns/ColumnMapperTests.cs
@@ -1,0 +1,79 @@
+using HomeBoxLanding.Api.Features.Columns;
+using HomeBoxLanding.Api.Features.Columns.Types;
+using HomeBoxLanding.Api.Features.Folders.Types;
+using HomeBoxLanding.Api.Features.Links.Types;
+using NUnit.Framework;
+
+namespace HomeBoxLanding.Api.Tests.Features.Columns;
+
+[TestFixture]
+public class ColumnMapperTests
+{
+    [Test]
+    public void Map_OrdersLooseLinksAndExcludesLinksOwnedByFolders()
+    {
+        var folderIdentifier = Guid.NewGuid();
+        var looseLink = CreateLink("loose", 1, null);
+        var folderLink = CreateLink("folder-link", 0, folderIdentifier);
+        var laterLooseLink = CreateLink("later", 2, null);
+        var record = new ColumnRecord
+        {
+            Identifier = Guid.NewGuid(),
+            Name = "Services",
+            Icon = "server",
+            Links = [laterLooseLink, folderLink, looseLink]
+        };
+
+        var result = ColumnMapper.Map(record);
+
+        Assert.That(result.Links.Select(x => x.Name), Is.EqualTo(["loose", "later"]));
+        Assert.That(result.Links.Any(x => x.Name == "folder-link"), Is.False);
+    }
+
+    [Test]
+    public void Map_OrdersFoldersAndMapsTheirLinks()
+    {
+        var folderLink = CreateLink("folder-link", 1, Guid.NewGuid());
+        var firstFolder = new FolderRecord
+        {
+            Identifier = Guid.NewGuid(),
+            Name = "First",
+            Icon = "folder",
+            SortOrder = 1,
+            Links = [folderLink]
+        };
+        var secondFolder = new FolderRecord
+        {
+            Identifier = Guid.NewGuid(),
+            Name = "Second",
+            Icon = "folder",
+            SortOrder = 0
+        };
+        var record = new ColumnRecord
+        {
+            Identifier = Guid.NewGuid(),
+            Name = "Services",
+            Icon = "server",
+            Folders = [firstFolder, secondFolder]
+        };
+
+        var result = ColumnMapper.Map(record);
+
+        Assert.That(result.Folders.Select(x => x.Name), Is.EqualTo(["Second", "First"]));
+        Assert.That(result.Folders[1].Links.Select(x => x.Name), Is.EqualTo(["folder-link"]));
+    }
+
+    private static LinkRecord CreateLink(string name, int sortOrder, Guid? folderIdentifier)
+    {
+        return new LinkRecord
+        {
+            Identifier = Guid.NewGuid(),
+            Name = name,
+            Url = $"https://{name}.example.com",
+            Host = $"{name}.example.com",
+            IconUrl = "icon.png",
+            SortOrder = sortOrder,
+            FolderIdentifier = folderIdentifier
+        };
+    }
+}

--- a/api/home-box-landing/HomeBoxLanding.Api.Tests/Features/FuelPricePoller/HaversineTests.cs
+++ b/api/home-box-landing/HomeBoxLanding.Api.Tests/Features/FuelPricePoller/HaversineTests.cs
@@ -1,0 +1,24 @@
+using HomeBoxLanding.Api.Features.FuelPricePoller;
+using NUnit.Framework;
+
+namespace HomeBoxLanding.Api.Tests.Features.FuelPricePoller;
+
+[TestFixture]
+public class HaversineTests
+{
+    [Test]
+    public void Calculate_ReturnsZeroForTheSameCoordinates()
+    {
+        var distance = Haversine.Calculate(51.5074, -0.1278, 51.5074, -0.1278);
+
+        Assert.That(distance, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void Calculate_ReturnsDistanceInRoundedMeters()
+    {
+        var distance = Haversine.Calculate(0, 0, 0, 1);
+
+        Assert.That(distance, Is.EqualTo(111195));
+    }
+}

--- a/src/core/map-network-error.spec.ts
+++ b/src/core/map-network-error.spec.ts
@@ -1,0 +1,78 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { throwError } from 'rxjs';
+import { ErrorCodes, mapNetworkError, UserError } from './map-network-error';
+
+describe('mapNetworkError', () => {
+    it('maps common HTTP statuses to user-facing errors', () => {
+        const cases = [
+            {
+                status: 0,
+                code: ErrorCodes.OFFLINE,
+                message: 'You\'re offline, unable to communicate with servers. Try checking your internet connection.'
+            },
+            {
+                status: 503,
+                code: ErrorCodes.OFFLINE,
+                message: 'Apologies, servers can\'t be reached at this time. Try again in a few minutes.'
+            },
+            {
+                status: 500,
+                code: ErrorCodes.NETWORK_EXCEPTION,
+                message: 'Apologies, servers were unable to complete that request due to an internal error. Please contact support if this error still persists.'
+            },
+            {
+                status: 401,
+                code: ErrorCodes.MISSING_PERMISSIONS,
+                message: 'You do not have the correct permissions to complete this request. Please contact your local administrator for more information.'
+            }
+        ];
+
+        for (const testCase of cases) {
+            let receivedError: UserError | undefined;
+            throwError(() => new HttpErrorResponse({ status: testCase.status }))
+                .pipe(mapNetworkError())
+                .subscribe({
+                    error: (error: UserError) => {
+                        receivedError = error;
+                    }
+                });
+
+            expect(receivedError).toBeInstanceOf(UserError);
+            expect(receivedError?.code).toBe(testCase.code);
+            expect(receivedError?.message).toBe(testCase.message);
+        }
+    });
+
+    it('uses the API message for invalid requests', () => {
+        let receivedError: UserError | undefined;
+
+        throwError(() => new HttpErrorResponse({
+            status: 400,
+            error: { UserMessage: 'The link could not be saved.' }
+        }))
+            .pipe(mapNetworkError())
+            .subscribe({
+                error: (error: UserError) => {
+                    receivedError = error;
+                }
+            });
+
+        expect(receivedError?.code).toBe(ErrorCodes.INVALID_ACTION);
+        expect(receivedError?.message).toBe('The link could not be saved.');
+    });
+
+    it('passes through non-HTTP errors unchanged', () => {
+        const originalError = new Error('unexpected failure');
+        let receivedError: unknown;
+
+        throwError(() => originalError)
+            .pipe(mapNetworkError())
+            .subscribe({
+                error: (error: unknown) => {
+                    receivedError = error;
+                }
+            });
+
+        expect(receivedError).toBe(originalError);
+    });
+});

--- a/src/core/stack.spec.ts
+++ b/src/core/stack.spec.ts
@@ -1,0 +1,23 @@
+import { Stack } from './stack';
+
+describe('Stack', () => {
+    it('stores and removes items in last-in-first-out order', () => {
+        const stack = new Stack<string>();
+
+        stack.push('first');
+        stack.push('second');
+
+        expect(stack.peek()).toBe('second');
+        expect(stack.size()).toBe(2);
+        expect(stack.pop()).toBe('second');
+        expect(stack.pop()).toBe('first');
+        expect(stack.size()).toBe(0);
+    });
+
+    it('returns undefined when reading an empty stack', () => {
+        const stack = new Stack<number>();
+
+        expect(stack.peek()).toBeUndefined();
+        expect(stack.pop()).toBeUndefined();
+    });
+});

--- a/src/core/terminal-parser.spec.ts
+++ b/src/core/terminal-parser.spec.ts
@@ -1,0 +1,15 @@
+import { TerminalParser } from './terminal-parser';
+
+describe('TerminalParser', () => {
+    it('returns an empty string when no terminal output is provided', () => {
+        expect(new TerminalParser('').toHtml()).toBe('');
+    });
+
+    it('converts terminal colors, escaped newlines, and escaped quotes to HTML', () => {
+        const output = '\u001b[0;36mcyan\u001b[0m\\n\u001b[0;32mgreen\u001b[0m\\n\\"quoted\\"';
+
+        expect(new TerminalParser(output).toHtml()).toBe(
+            '<span class="text-cyan">cyan</span><br /><span class="text-green">green</span><br />"quoted"'
+        );
+    });
+});


### PR DESCRIPTION
## Summary

- Add Angular regression specs for stack behavior, terminal output parsing, and network error mapping.
- Add .NET regression specs for Haversine distance calculations and column/folder link mapping.
- Enable the existing Angular CI test step so frontend regressions run in pull requests.

## Validation

- `npm run test-ci` — 9 tests passed.
- `npm run lint` — passed.
- `dotnet test api/home-box-landing/HomeBoxLanding.sln --no-restore` — 12 tests passed.

Existing Sass deprecation, nullable-reference, and package vulnerability warnings remain unchanged.

This pull request was created by an AI agent (OpenHands) on behalf of the user.
