### PR TITLE
test: improve frontend coverage and add Codecov badge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,13 @@ jobs:
       - name: Test FE
         run: npm run test-ci
 
+      - name: Upload frontend coverage
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./coverage/home-box-landing/lcov.info
+          flags: frontend
+          fail_ci_if_error: true
+
 
   lint-fe:
     runs-on: self-hosted

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ examples/*
 !examples/.env
 api/home-box-landing/HomeBoxLanding.sln.DotSettings.user
 api/home-box-landing/HomeBoxLanding.Api/Properties/launchSettings.json
+
+.openhands/memories/

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@
 <a href="https://hub.docker.com/r/citr0s/home-app"><img src="https://img.shields.io/docker/v/citr0s/home-app?sort=semver" alt="Docker version"></a>
 </p>
 
+<p align="center">
+  <a href="https://codecov.io/gh/citr0sco/home-app"><img src="https://codecov.io/gh/citr0sco/home-app/branch/main/graph/badge.svg" alt="Code Coverage"></a>
+</p>
+
 ---
 
 <h4 align="center">Home App is a self-hosted web app designed to provide you with better dashboard for a homelab.</h4>

--- a/angular.json
+++ b/angular.json
@@ -114,6 +114,7 @@
                         ],
                         "coverageReporters": [
                           "html",
+                          "lcov",
                           "text-summary"
                         ],
                         "buildTarget": ":build:testing",

--- a/src/services/data-mappers.spec.ts
+++ b/src/services/data-mappers.spec.ts
@@ -1,0 +1,69 @@
+import { LocationMapper } from './location-service/location.mapper';
+import { NotepadMapper } from './notepad-service/notepad.mapper';
+import { WeatherMapper } from './weather-service/weather.mapper';
+import { PiHoleMapper } from './pihole-service/pi-hole.mapper';
+import { PlexMapper } from './plex-service/plex.mapper';
+import { UptimeKumaMapper } from './uptime-kuma-service/uptime-kuma.mapper';
+import { StatMapper } from './stats-service/stat.mapper';
+
+describe('data mappers', () => {
+    it('maps browser and API location shapes, including an empty location', () => {
+        const empty = LocationMapper.map(null);
+        expect(empty.latitude).toBe(0);
+        expect(empty.longitude).toBe(0);
+        expect(LocationMapper.map({ coords: { latitude: 1, longitude: 2 } }))
+            .toMatchObject({ latitude: 1, longitude: 2 });
+        expect(LocationMapper.map({ latitude: 3, longitude: 4 }))
+            .toMatchObject({ latitude: 3, longitude: 4 });
+    });
+
+    it('maps notes and weather responses', () => {
+        const note = NotepadMapper.map({
+            Identifier: 'note-id', Note: 'Remember this',
+            CreatedAt: '2026-01-01T00:00:00.000Z', UpdatedAt: '2026-01-02T00:00:00.000Z'
+        });
+        expect(note.identifier).toBe('note-id');
+        expect(note.createdAt.toISOString()).toBe('2026-01-01T00:00:00.000Z');
+        expect(note.updatedAt.toISOString()).toBe('2026-01-02T00:00:00.000Z');
+
+        const weather = WeatherMapper.map({
+            name: 'London', weather: [{ main: 'Clouds', description: 'broken clouds' }],
+            coord: { lat: 51.5, lon: -0.1 }, main: {
+                feels_like: 12, humidity: 80, pressure: 1012, temp: 13, temp_max: 15, temp_min: 10
+            }, wind: { deg: 180, gust: 5, speed: 3 }
+        });
+        expect(weather).toMatchObject({
+            name: 'London', weatherShortDescription: 'Clouds', weatherDescription: 'broken clouds',
+            latitude: 51.5, longitude: -0.1, temperature: 13, windSpeed: 3
+        });
+    });
+
+    it('maps monitoring and resource payloads', () => {
+        const uptime = UptimeKumaMapper.mapActivities({ Response: { Data: {
+            Activities: [{ Metrics: [{ Name: 'Website', IsUp: true }] }]
+        } } });
+        expect(uptime).toEqual([{ metrics: [{ name: 'Website', isUp: true }] }]);
+
+        const pihole = PiHoleMapper.mapActivities({ Response: { Data: {
+            Activities: [{ Identifier: 'pi', Queries: { Total: 10, Blocked: 2, PercentBlocked: 20 }, Clients: { Total: 3 } }]
+        } } });
+        expect(pihole[0]).toEqual({ identifier: 'pi', queriesToday: 10, blockedToday: 2, blockedPercentage: 20, clients: 3 });
+        expect(PiHoleMapper.mapActivity({ Identifier: 'pi' })).toEqual({
+            identifier: 'pi', queriesToday: undefined, blockedToday: undefined,
+            blockedPercentage: undefined, clients: undefined
+        });
+
+        const plex = PlexMapper.mapActivity({ Response: { Data: { Sessions: [
+            { User: 'Alex', Duration: null, FullTitle: 'Live', State: 'playing', ViewOffset: null,
+                ProgressPercentage: 0, VideoDecision: 'directplay' }
+        ] } } });
+        expect(plex[0]).toMatchObject({ user: 'Alex', progressPercentage: 100, isLiveTv: true });
+
+        const stats = StatMapper.map({ Stats: [{ Name: 'app', CpuUsage: { Percentage: 1 } }] });
+        expect(stats.stats[0]).toEqual({
+            name: 'app', cpuUsage: { percentage: 1, total: undefined, used: undefined },
+            memoryUsage: { percentage: undefined, total: undefined, used: undefined },
+            diskUsage: { percentage: undefined, total: undefined, used: undefined }
+        });
+    });
+});

--- a/src/services/link-service/column-items.spec.ts
+++ b/src/services/link-service/column-items.spec.ts
@@ -1,0 +1,71 @@
+import { ColumnItems } from './column-items';
+import { IColumn } from './types/column.type';
+import { IFolder } from './types/folder.type';
+import { ILink } from './types/link.type';
+
+describe('ColumnItems', () => {
+    const link = (name: string, sortOrder: number): ILink => ({
+        identifier: `${name}-id`,
+        containerName: null,
+        name,
+        url: `https://${name}.example.com`,
+        host: `${name}.example.com`,
+        port: 443,
+        iconUrl: `${name}.png`,
+        sortOrder,
+        columnId: 'old-column',
+        folderId: 'old-folder'
+    });
+
+    const folder = (name: string, sortOrder: number, links: Array<ILink> = []): IFolder => ({
+        identifier: `${name}-id`,
+        name,
+        icon: 'folder',
+        sortOrder,
+        columnId: 'old-column',
+        links
+    });
+
+    it('sorts links and folders together by their sort order', () => {
+        const column: IColumn = {
+            identifier: 'column-id',
+            name: 'Services',
+            sortOrder: 0,
+            icon: 'server',
+            links: [link('later', 2), link('first', 0)],
+            folders: [folder('middle', 1)]
+        };
+
+        expect(ColumnItems.sort(column).map((item) => item.kind === 'link' ? item.link.name : item.folder.name))
+            .toEqual(['first', 'middle', 'later']);
+        expect(ColumnItems.isFolder(column.folders[0])).toBe(true);
+        expect(ColumnItems.isFolder(column.links[0])).toBe(false);
+    });
+
+    it('writes reordered items and updates ownership metadata', () => {
+        const nestedLink = link('nested', 99);
+        const looseLink = link('loose', 99);
+        const nestedFolder = folder('nested-folder', 99, [nestedLink]);
+        const column: IColumn = {
+            identifier: 'column-id',
+            name: 'Services',
+            sortOrder: 0,
+            icon: 'server',
+            links: [],
+            folders: []
+        };
+
+        ColumnItems.write(column, [ColumnItems.wrap(nestedFolder), ColumnItems.wrap(looseLink)]);
+
+        expect(column.folders).toEqual([nestedFolder]);
+        expect(column.links).toEqual([looseLink]);
+        expect(nestedFolder.sortOrder).toBe(0);
+        expect(nestedFolder.columnId).toBe('column-id');
+        expect(nestedLink.sortOrder).toBe(0);
+        expect(nestedLink.columnId).toBe('column-id');
+        expect(nestedLink.folderId).toBe('nested-folder-id');
+        expect(looseLink.sortOrder).toBe(1);
+        expect(looseLink.columnId).toBe('column-id');
+        expect(looseLink.folderId).toBeNull();
+    });
+});

--- a/src/services/link-service/mappers.spec.ts
+++ b/src/services/link-service/mappers.spec.ts
@@ -1,0 +1,91 @@
+import { ColumnMapper } from './column.mapper';
+import { FolderMapper } from './folder.mapper';
+import { LinkMapper } from './link.mapper';
+import { IColumn } from './types/column.type';
+import { IFolder } from './types/folder.type';
+import { ILink } from './types/link.type';
+
+describe('link service mappers', () => {
+    const apiLink = {
+        Identifier: 'link-id',
+        containerName: 'container',
+        Name: 'Dashboard',
+        Url: 'https://example.com',
+        Host: 'example.com',
+        Port: 443,
+        IconUrl: 'icon.png',
+        SortOrder: 2,
+        ColumnId: 'column-id',
+        FolderId: undefined,
+        Category: 'tools'
+    };
+
+    it('maps links from and to the API shape', () => {
+        const mapped = LinkMapper.mapSingle(apiLink);
+
+        expect(mapped.folderId).toBeNull();
+        expect(mapped.name).toBe('Dashboard');
+        expect(LinkMapper.map([apiLink])).toEqual([mapped]);
+        expect(LinkMapper.mapToApiSingle(mapped)).toEqual({
+            Identifier: 'link-id',
+            ContainerName: 'container',
+            Name: 'Dashboard',
+            Url: 'https://example.com',
+            Host: 'example.com',
+            Port: 443,
+            IconUrl: 'icon.png',
+            SortOrder: 2,
+            ColumnId: 'column-id',
+            FolderId: null,
+            Category: 'tools'
+        });
+    });
+
+    it('maps folders and columns, including nested links', () => {
+        const apiFolder = {
+            Identifier: 'folder-id',
+            Name: 'Tools',
+            Icon: 'folder',
+            SortOrder: 1,
+            ColumnId: 'column-id',
+            Links: [apiLink]
+        };
+        const apiColumn = {
+            Identifier: 'column-id',
+            Name: 'Services',
+            SortOrder: 0,
+            Icon: 'server',
+            Links: [apiLink],
+            Folders: [apiFolder]
+        };
+
+        const folder = FolderMapper.mapSingle(apiFolder);
+        const column = ColumnMapper.mapSingle(apiColumn);
+
+        expect(folder.links[0].name).toBe('Dashboard');
+        expect(FolderMapper.mapToApi([folder])[0].Links[0].Name).toBe('Dashboard');
+        expect(column.folders[0].name).toBe('Tools');
+        expect(column.links[0].name).toBe('Dashboard');
+        expect(ColumnMapper.map([apiColumn])).toEqual([column]);
+    });
+
+    it('maps local folders and columns back to API collections', () => {
+        const link: ILink = {
+            identifier: 'link-id', containerName: null, name: 'Dashboard', url: 'https://example.com',
+            host: 'example.com', port: 443, iconUrl: 'icon.png', sortOrder: 0,
+            columnId: 'column-id', folderId: null
+        };
+        const folder: IFolder = {
+            identifier: 'folder-id', name: 'Tools', icon: 'folder', sortOrder: 1,
+            columnId: 'column-id', links: [link]
+        };
+        const column: IColumn = {
+            identifier: 'column-id', name: 'Services', sortOrder: 0, icon: 'server',
+            links: [link], folders: [folder]
+        };
+
+        expect(FolderMapper.mapToApi([folder])).toHaveLength(1);
+        expect(ColumnMapper.mapToApi([column])).toHaveLength(1);
+        expect(ColumnMapper.mapToApiSingle(column).Folders[0].Identifier).toBe('folder-id');
+    });
+});

--- a/src/services/websocket-service/web-socket.service.spec.ts
+++ b/src/services/websocket-service/web-socket.service.spec.ts
@@ -1,0 +1,87 @@
+import { WebSocketService } from './web-socket.service';
+import { WebSocketKey } from './types/web-socket.key';
+
+class FakeWebSocket {
+    public static INSTANCES: Array<FakeWebSocket> = [];
+    public onopen: (() => void) | null = null;
+    public onmessage: ((event: { data: string }) => void) | null = null;
+    public onclose: (() => void) | null = null;
+    public onerror: ((event: unknown) => void) | null = null;
+    public sent: Array<string> = [];
+    public readonly url: string;
+
+    public constructor(url: string) {
+        this.url = url;
+        FakeWebSocket.INSTANCES.push(this);
+    }
+
+    public send(payload: string): void {
+        this.sent.push(payload);
+    }
+}
+
+describe('WebSocketService', () => {
+    const originalWebSocket = globalThis.WebSocket;
+
+    beforeEach(() => {
+        localStorage.clear();
+        FakeWebSocket.INSTANCES = [];
+        (globalThis as { WebSocket: typeof WebSocket }).WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+        Object.defineProperty(WebSocketService, '_INSTANCE', { value: null, writable: true });
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        (globalThis as { WebSocket: typeof WebSocket }).WebSocket = originalWebSocket;
+        Object.defineProperty(WebSocketService, '_INSTANCE', { value: null, writable: true });
+        vi.useRealTimers();
+    });
+
+    it('queues messages until ready and sends them with the session', () => {
+        const service = WebSocketService.instance();
+        const socket = FakeWebSocket.INSTANCES[0];
+
+        expect(socket.url).toBe('wss://localhost:7058/ws');
+        service.send(WebSocketKey.ServerStats, { refresh: true });
+        expect(socket.sent).toEqual([]);
+
+        service.handleOpen();
+        vi.advanceTimersByTime(1000);
+
+        expect(socket.sent).toEqual([JSON.stringify({
+            Key: WebSocketKey.ServerStats,
+            Data: { refresh: true },
+            SessionId: null
+        })]);
+    });
+
+    it('stores handshakes and notifies subscribers of messages', () => {
+        const service = WebSocketService.instance();
+        const callback = vi.fn();
+        service.subscribe(WebSocketKey.PlexActivity, callback);
+        service.subscribe(WebSocketKey.PlexActivity, callback);
+
+        service.handleMessage({ data: JSON.stringify({ Key: WebSocketKey.Handshake, Data: 'session-id' }) });
+        expect(localStorage.getItem('sessionId')).toBe('session-id');
+
+        service.handleMessage({ data: JSON.stringify({ Key: WebSocketKey.PlexActivity, Data: { title: 'Movie' } }) });
+        expect(callback).toHaveBeenCalledTimes(2);
+        expect(callback).toHaveBeenCalledWith({ title: 'Movie' });
+    });
+
+    it('sends unsubscriptions and publishes connection lifecycle state', () => {
+        const service = WebSocketService.instance();
+        const socket = FakeWebSocket.INSTANCES[0];
+        const connectionStates: Array<boolean> = [];
+        service.isConnected.subscribe((state) => connectionStates.push(state));
+
+        service.handleOpen();
+        service.unsubscribe({ Key: WebSocketKey.ServerStats });
+        service.handleClose();
+        service.handleError(new Error('failed'));
+
+        expect(socket.sent).toEqual([JSON.stringify({ Key: WebSocketKey.ServerStats })]);
+        expect(connectionStates).toEqual([true, false]);
+        expect(localStorage.getItem('sessionId')).toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary
- add focused frontend tests for data mappers, link/folder/column mapping, column ordering, and WebSocket behavior
- emit lcov coverage reports and upload frontend coverage to Codecov
- add the Codecov percentage badge to the README
- keep `.openhands/memories/MEMORY.md` local and ignored

## Validation
- `npm run test-ci` — 20 tests passed across 8 files
- Coverage: 85.51% lines, 86.14% statements, 70.42% branches, 86.20% functions
- `npm run lint` — passed
- `npm run build` — passed (existing Sass deprecation and bundle-budget warnings)

This pull request was created by an AI agent (OpenHands) on behalf of the user.
