### PR TITLE
feat: add dynamic server statistics ranges

### DIFF
--- a/api/home-box-landing/HomeBoxLanding.Api.Tests/Features/Stats/ServerStatsHistoryEndpointTests.cs
+++ b/api/home-box-landing/HomeBoxLanding.Api.Tests/Features/Stats/ServerStatsHistoryEndpointTests.cs
@@ -29,6 +29,26 @@ public class ServerStatsHistoryEndpointTests
         Assert.That(result.Samples[0].CpuPercentage, Is.EqualTo(20));
     }
 
+    [Test]
+    public async Task UsesTheRequestedHistoryRange()
+    {
+        var repository = new RecordingHistoryRepository();
+        var service = new StatsService(
+            new Mock<IShellService>().Object,
+            new EmptyStatsCache(),
+            repository,
+            cpuCount: 1);
+
+        var before = DateTime.UtcNow;
+        var result = await service.GetServerStatsHistoryAsync(6);
+        var after = DateTime.UtcNow;
+
+        Assert.That(repository.Since, Is.GreaterThanOrEqualTo(before.AddHours(-6)));
+        Assert.That(repository.Since, Is.LessThanOrEqualTo(after.AddHours(-6)));
+        Assert.That(result.To, Is.GreaterThanOrEqualTo(before));
+        Assert.That(result.From, Is.GreaterThanOrEqualTo(before.AddHours(-6)));
+    }
+
     private sealed class EmptyStatsCache : IStatsServiceCache
     {
         public StatsResponse? GetStats() => null;
@@ -39,6 +59,21 @@ public class ServerStatsHistoryEndpointTests
     {
         public Task SaveAsync(ServerStatsHistoryRecord record, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task<List<ServerStatsHistoryRecord>> GetSinceAsync(DateTime since, CancellationToken cancellationToken = default) => Task.FromResult(new List<ServerStatsHistoryRecord>());
+        public Task<int> DeleteOlderThanAsync(DateTime cutoff, CancellationToken cancellationToken = default) => Task.FromResult(0);
+    }
+
+    private sealed class RecordingHistoryRepository : IServerStatsHistoryRepository
+    {
+        public DateTime Since { get; private set; }
+
+        public Task SaveAsync(ServerStatsHistoryRecord record, CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public Task<List<ServerStatsHistoryRecord>> GetSinceAsync(DateTime since, CancellationToken cancellationToken = default)
+        {
+            Since = since;
+            return Task.FromResult(new List<ServerStatsHistoryRecord>());
+        }
+
         public Task<int> DeleteOlderThanAsync(DateTime cutoff, CancellationToken cancellationToken = default) => Task.FromResult(0);
     }
 }

--- a/api/home-box-landing/HomeBoxLanding.Api/Features/Stats/StatsController.cs
+++ b/api/home-box-landing/HomeBoxLanding.Api/Features/Stats/StatsController.cs
@@ -22,8 +22,10 @@ public class StatsController : ControllerBase
     }
 
     [HttpGet("history")]
-    public async Task<ServerStatsHistoryResponse> GetHistory(CancellationToken cancellationToken)
+    public async Task<ServerStatsHistoryResponse> GetHistory(
+        [FromQuery] int hours = 24,
+        CancellationToken cancellationToken = default)
     {
-        return await _service.GetServerStatsHistoryAsync(cancellationToken);
+        return await _service.GetServerStatsHistoryAsync(hours, cancellationToken);
     }
 }

--- a/api/home-box-landing/HomeBoxLanding.Api/Features/Stats/StatsService.cs
+++ b/api/home-box-landing/HomeBoxLanding.Api/Features/Stats/StatsService.cs
@@ -111,10 +111,12 @@ public class StatsService : ISubscriber
     }
 
     public async Task<ServerStatsHistoryResponse> GetServerStatsHistoryAsync(
+        int hours = 24,
         CancellationToken cancellationToken = default)
     {
+        var rangeHours = Math.Clamp(hours, 1, 24 * 7);
         var to = DateTime.UtcNow;
-        var from = to.AddHours(-24);
+        var from = to.AddHours(-rangeHours);
 
         try
         {

--- a/src/pages/server-stats-page/server-stats-page.component.html
+++ b/src/pages/server-stats-page/server-stats-page.component.html
@@ -3,10 +3,16 @@
 
   <main class="container server-stats-page__content">
     <section class="server-stats-page__range">
-      <div class="range-badge">
+      <label class="range-selector">
         <i class="far fa-clock"></i>
-        <span>{{ rangeLabel() }}</span>
-      </div>
+        <span class="visually-hidden">Statistics time range</span>
+        <select [value]="selectedRangeHours()" (change)="onRangeChange($event)">
+          @for (range of ranges; track range.hours) {
+            <option [value]="range.hours">{{ range.label }}</option>
+          }
+        </select>
+      </label>
+      <span class="range-label">{{ rangeLabel() }}</span>
     </section>
 
     @if (isLoading()) {
@@ -57,12 +63,16 @@
                   <polygon [attr.points]="chartArea(chart.key)" [attr.fill]="chart.color" class="chart-area"></polygon>
                   <polyline [attr.points]="chartLine(chart.key)" fill="none" [attr.stroke]="chart.color" class="chart-line"></polyline>
                   @if (samples().length > 0) {
-                    <circle [attr.cx]="chartPointX(samples().length - 1)" [attr.cy]="chartPointY(samples()[samples().length - 1], chart.key)" r="4" [attr.fill]="chart.color" class="chart-dot">
+                    <circle [attr.cx]="chartPointX(samples()[samples().length - 1])" [attr.cy]="chartPointY(samples()[samples().length - 1], chart.key)" r="4" [attr.fill]="chart.color" class="chart-dot">
                       <title>{{ formatPercentage(currentValue(chart.key)) }} at {{ formatTimestamp(samples()[samples().length - 1].recordedAt) }}</title>
                     </circle>
                   }
                 </svg>
-                <div class="chart-card__axis"><span>24 hours ago</span><span>12 hours ago</span><span>Now</span></div>
+                <div class="chart-card__axis">
+                  @for (label of axisLabels(); track $index) {
+                    <span>{{ label }}</span>
+                  }
+                </div>
               </div>
 
               <footer class="chart-card__footer">

--- a/src/pages/server-stats-page/server-stats-page.component.scss
+++ b/src/pages/server-stats-page/server-stats-page.component.scss
@@ -4,12 +4,14 @@
     min-height: 100vh;
 
     &__content { padding: 32px 16px 48px; }
-    &__range { display: flex; justify-content: flex-end; padding: 0 0 24px; }
+    &__range { display: flex; align-items: center; justify-content: flex-end; gap: 12px; padding: 0 0 24px; }
 }
 
 .eyebrow { color: $info-color; text-transform: uppercase; letter-spacing: .16em; font-size: .65rem; font-weight: 700; }
-.range-badge { border: 1px solid rgba(255, 255, 255, .12); background: rgba(0, 0, 0, .18); border-radius: $border-radius; padding: 10px 13px; color: rgba(255, 255, 255, .65); font-size: .75rem; white-space: nowrap; }
-.range-badge i { color: $info-color; margin-right: 7px; }
+.range-selector { display: inline-flex; align-items: center; gap: 8px; border: 1px solid rgba(255, 255, 255, .12); background: rgba(0, 0, 0, .18); border-radius: $border-radius; padding: 8px 11px; color: $info-color; font-size: .75rem; }
+.range-selector select { border: 0; outline: 0; background: transparent; color: rgba(255, 255, 255, .75); font: inherit; cursor: pointer; }
+.range-selector option { background: #1d2228; color: #fff; }
+.range-label { color: rgba(255, 255, 255, .42); font-size: .7rem; white-space: nowrap; }
 
 .chart-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; padding: 4px 0 12px; }
 .chart-card { min-width: 0; overflow: hidden; border: 1px solid rgba(255, 255, 255, .08); border-radius: $border-radius; background: rgba(0, 0, 0, .22); box-shadow: var(--box-shadow); animation: lift-in 400ms both; }
@@ -40,8 +42,9 @@
 
 @media (max-width: $tablet-width) { .chart-grid { grid-template-columns: 1fr; } }
 @media (max-width: $mobile-width) {
-    .server-stats-page__range { justify-content: stretch; }
-    .range-badge { width: 100%; }
+    .server-stats-page__range { align-items: stretch; flex-direction: column; }
+    .range-selector, .range-selector select { width: 100%; }
+    .range-label { text-align: right; }
     .chart-card__header { padding: 14px 13px 8px; }
     .chart-card__footer { padding-left: 13px; padding-right: 13px; }
 }

--- a/src/pages/server-stats-page/server-stats-page.component.ts
+++ b/src/pages/server-stats-page/server-stats-page.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnDestroy, OnInit, signal, WritableSignal } from '@angular/core';
-import { Subject, takeUntil } from 'rxjs';
+import { catchError, EMPTY, map, merge, Subject, switchMap, takeUntil, timer } from 'rxjs';
 import { StatService } from '../../services/stats-service/stat.service';
 import { IStatHistoryResponse, IStatHistorySample } from '../../services/stats-service/types/stat-history.response';
 
@@ -40,20 +40,42 @@ export class ServerStatsPageComponent implements OnInit, OnDestroy {
         }
     ];
 
+    public readonly ranges = [
+        { hours: 1, label: 'Last hour' },
+        { hours: 6, label: 'Last 6 hours' },
+        { hours: 12, label: 'Last 12 hours' },
+        { hours: 24, label: 'Last 24 hours' },
+        { hours: 24 * 7, label: 'Last 7 days' }
+    ];
+
     public history: WritableSignal<IStatHistoryResponse | null> = signal<IStatHistoryResponse | null>(null);
+    public selectedRangeHours: WritableSignal<number> = signal<number>(24);
     public isLoading: WritableSignal<boolean> = signal<boolean>(true);
     public hasError: WritableSignal<boolean> = signal<boolean>(false);
 
     private readonly _statService: StatService;
     private readonly _destroy: Subject<void> = new Subject();
+    private readonly _rangeChanges: Subject<number> = new Subject();
 
     constructor(statService: StatService) {
         this._statService = statService;
     }
 
     public ngOnInit(): void {
-        this._statService.getHistory()
-            .pipe(takeUntil(this._destroy))
+        merge(
+            timer(0, 15000).pipe(map(() => this.selectedRangeHours())),
+            this._rangeChanges
+        )
+            .pipe(
+                switchMap((hours) => this._statService.getHistory(hours).pipe(
+                    catchError(() => {
+                        this.hasError.set(true);
+                        this.isLoading.set(false);
+                        return EMPTY;
+                    })
+                )),
+                takeUntil(this._destroy)
+            )
             .subscribe({
                 next: (history) => {
                     this.history.set(history);
@@ -65,6 +87,18 @@ export class ServerStatsPageComponent implements OnInit, OnDestroy {
                     this.isLoading.set(false);
                 }
             });
+    }
+
+    public onRangeChange(event: Event): void {
+        const hours = Number((event.target as HTMLSelectElement).value);
+        if (!this.ranges.some((range) => range.hours === hours)) {
+            return;
+        }
+
+        this.selectedRangeHours.set(hours);
+        this.isLoading.set(true);
+        this.hasError.set(false);
+        this._rangeChanges.next(hours);
     }
 
     public samples(): Array<IStatHistorySample> {
@@ -105,9 +139,19 @@ export class ServerStatsPageComponent implements OnInit, OnDestroy {
         return `${first.x},204 ${this.chartLine(metric)} ${last.x},204`;
     }
 
-    public chartPointX(index: number): number {
-        const samples = this.samples();
-        return samples.length <= 1 ? 24 : 24 + (index / (samples.length - 1)) * 672;
+    public chartPointX(sample: IStatHistorySample): number {
+        const history = this.history();
+        if (!history) {
+            return 24;
+        }
+
+        const from = new Date(history.from).getTime();
+        const to = new Date(history.to).getTime();
+        const timestamp = new Date(sample.recordedAt).getTime();
+        const duration = to - from;
+        const progress = duration <= 0 ? 1 : Math.max(0, Math.min(1, (timestamp - from) / duration));
+
+        return 24 + progress * 672;
     }
 
     public chartPointY(sample: IStatHistorySample, metric: Metric): number {
@@ -123,13 +167,39 @@ export class ServerStatsPageComponent implements OnInit, OnDestroy {
         return new Date(timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
     }
 
+    public formatAxisTimestamp(timestamp: string): string {
+        const options: Intl.DateTimeFormatOptions = this.selectedRangeHours() > 24
+            ? { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' }
+            : { hour: '2-digit', minute: '2-digit' };
+
+        return new Date(timestamp).toLocaleString([], options);
+    }
+
     public rangeLabel(): string {
+        const range = this.ranges.find((item) => item.hours === this.selectedRangeHours());
         const history = this.history();
         if (!history) {
-            return 'Last 24 hours';
+            return range?.label ?? 'Selected range';
         }
 
-        return `${this.formatTimestamp(history.from)} — ${this.formatTimestamp(history.to)}`;
+        return `${range?.label ?? 'Selected range'} · ${this.formatAxisTimestamp(history.from)} — ${this.formatAxisTimestamp(history.to)}`;
+    }
+
+    public axisLabels(): [string, string, string] {
+        const history = this.history();
+        if (!history) {
+            return ['', '', ''];
+        }
+
+        const from = new Date(history.from).getTime();
+        const to = new Date(history.to).getTime();
+        const midpoint = new Date(from + ((to - from) / 2));
+
+        return [
+            this.formatAxisTimestamp(history.from),
+            this.formatAxisTimestamp(midpoint.toISOString()),
+            this.formatAxisTimestamp(history.to)
+        ];
     }
 
     public ngOnDestroy(): void {
@@ -139,10 +209,9 @@ export class ServerStatsPageComponent implements OnInit, OnDestroy {
 
     private chartCoordinates(metric: Metric): Array<{ x: number; y: number }> {
         const samples = this.samples();
-        const lastIndex = samples.length - 1;
 
-        return samples.map((sample, index) => ({
-            x: lastIndex <= 0 ? 24 : 24 + (index / lastIndex) * 672,
+        return samples.map((sample) => ({
+            x: this.chartPointX(sample),
             y: this.chartPointY(sample, metric)
         }));
     }

--- a/src/services/stats-service/stat.repository.ts
+++ b/src/services/stats-service/stat.repository.ts
@@ -24,8 +24,8 @@ export class StatRepository {
             );
     }
 
-    public getHistory(): Observable<IStatHistoryResponse> {
-        return this._httpClient.get(`${environment.apiBaseUrl}/api/stats/history`)
+    public getHistory(hours: number = 24): Observable<IStatHistoryResponse> {
+        return this._httpClient.get(`${environment.apiBaseUrl}/api/stats/history?hours=${hours}`)
             .pipe(
                 map((response: any) => ({
                     hasError: response.HasError ?? false,

--- a/src/services/stats-service/stat.service.ts
+++ b/src/services/stats-service/stat.service.ts
@@ -44,8 +44,8 @@ export class StatService {
             }));
     }
 
-    public getHistory(): Observable<IStatHistoryResponse> {
-        return this._statRepository.getHistory();
+    public getHistory(hours: number = 24): Observable<IStatHistoryResponse> {
+        return this._statRepository.getHistory(hours);
     }
 
     public handleNewStats(payload: any): void {


### PR DESCRIPTION
## Summary

- add selectable server statistics ranges: 1 hour, 6 hours, 12 hours, 24 hours, and 7 days
- add a bounded `hours` parameter to the server history endpoint
- refresh the selected history window every 15 seconds, matching dashboard updates
- position graph samples using their recorded timestamps instead of evenly spacing recent samples across the full chart
- derive axis labels and range text from the actual returned time window
- add backend coverage for requested history ranges

## Validation

- `npm run lint`
- `npm run test-ci` — 36 tests passed
- `npm run build`
- `dotnet test api/home-box-landing/HomeBoxLanding.Api.Tests/HomeBoxLanding.Api.Tests.csproj --no-restore` — 15 tests passed

Existing Sass deprecation, bundle-budget, nullable, and SQLite vulnerability warnings remain.

This pull request was created by an AI agent (OpenHands) on behalf of the user.