### PR TITLE
fix: update server stats charts live

### DIFF
--- a/src/pages/server-stats-page/server-stats-page.component.html
+++ b/src/pages/server-stats-page/server-stats-page.component.html
@@ -8,7 +8,7 @@
         <span class="visually-hidden">Statistics time range</span>
         <select [value]="selectedRangeHours()" (change)="onRangeChange($event)">
           @for (range of ranges; track range.hours) {
-            <option [value]="range.hours">{{ range.label }}</option>
+            <option [value]="range.hours" [selected]="range.hours === selectedRangeHours()">{{ range.label }}</option>
           }
         </select>
       </label>

--- a/src/pages/server-stats-page/server-stats-page.component.scss
+++ b/src/pages/server-stats-page/server-stats-page.component.scss
@@ -34,7 +34,7 @@
 .chart-hover-line { stroke-dasharray: 3 4; stroke-opacity: .55; pointer-events: none; }
 .chart-hover-dot { stroke: #fff; stroke-width: 1.5; pointer-events: none; }
 .chart-tooltip rect { fill: rgba(15, 18, 22, .92); stroke: rgba(255, 255, 255, .18); }
-.chart-tooltip text { fill: #fff; font-size: 8px; text-anchor: middle; dominant-baseline: middle; }
+.chart-tooltip text { fill: #fff; font-size: 10px; text-anchor: middle; dominant-baseline: middle; }
 .chart-card__axis, .chart-card__footer { display: flex; justify-content: space-between; color: rgba(255, 255, 255, .35); font-size: .63rem; }
 .chart-card__axis { padding: 0 34px 12px 14px; }
 .chart-card__footer { border-top: 1px solid rgba(255, 255, 255, .07); padding: 11px 17px 13px; }

--- a/src/pages/server-stats-page/server-stats-page.component.ts
+++ b/src/pages/server-stats-page/server-stats-page.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnDestroy, OnInit, signal, WritableSignal } from '@angular/core';
 import { catchError, EMPTY, map, merge, Subject, switchMap, takeUntil, timer } from 'rxjs';
 import { StatService } from '../../services/stats-service/stat.service';
+import { IStatResponse } from '../../services/stats-service/types/stat.response';
 import { IStatHistoryResponse, IStatHistorySample } from '../../services/stats-service/types/stat-history.response';
 
 type Metric = 'cpuPercentage' | 'memoryPercentage' | 'diskPercentage';
@@ -63,6 +64,10 @@ export class ServerStatsPageComponent implements OnInit, OnDestroy {
     }
 
     public ngOnInit(): void {
+        this._statService.stats
+            .pipe(takeUntil(this._destroy))
+            .subscribe((stats) => this.appendLiveSample(stats));
+
         merge(
             timer(0, 15000).pipe(map(() => this.selectedRangeHours())),
             this._rangeChanges
@@ -241,6 +246,38 @@ export class ServerStatsPageComponent implements OnInit, OnDestroy {
         this._destroy.complete();
     }
 
+    private appendLiveSample(stats: IStatResponse | null): void {
+        if (!stats || stats.stats.length === 0 || !this.history()) {
+            return;
+        }
+
+        const memoryUsed = stats.stats.reduce((total, stat) => total + (stat.memoryUsage?.used ?? 0), 0);
+        const memoryTotal = Math.max(...stats.stats.map((stat) => stat.memoryUsage?.total ?? 0));
+        const diskUsed = Math.max(...stats.stats.map((stat) => stat.diskUsage?.used ?? 0));
+        const diskTotal = Math.max(...stats.stats.map((stat) => stat.diskUsage?.total ?? 0));
+        const recordedAt = new Date();
+        const liveSample: IStatHistorySample = {
+            recordedAt: recordedAt.toISOString(),
+            cpuPercentage: Math.min(100, stats.stats.reduce((total, stat) => total + (stat.cpuUsage?.percentage ?? 0), 0)),
+            memoryPercentage: memoryTotal > 0 ? (memoryUsed / memoryTotal) * 100 : 0,
+            memoryUsed,
+            memoryTotal,
+            diskPercentage: diskTotal > 0 ? (diskUsed / diskTotal) * 100 : 0,
+            diskUsed,
+            diskTotal
+        };
+        const to = recordedAt.getTime();
+        const from = to - this.selectedRangeHours() * 60 * 60 * 1000;
+        const history = this.history()!;
+        const samples = [...history.samples, liveSample]
+            .filter((sample) => {
+                const timestamp = new Date(sample.recordedAt).getTime();
+                return timestamp >= from && timestamp <= to;
+            })
+            .sort((left, right) => new Date(left.recordedAt).getTime() - new Date(right.recordedAt).getTime());
+
+        this.history.set({ ...history, from: new Date(from).toISOString(), to: recordedAt.toISOString(), samples });
+    }
     private chartCoordinates(metric: Metric): Array<{ x: number; y: number }> {
         const samples = this.samples();
 


### PR DESCRIPTION
## Summary

- explicitly keep the server stats dropdown on the 24-hour option during initial rendering
- append aggregated CPU, memory, and disk samples to the selected rolling graph window as WebSocket stats arrive
- keep live samples aligned with the persisted backend aggregation rules
- increase chart hover labels from 8px to 10px for easier reading

## Validation

- `npm run lint`
- `npm run test-ci` (36 tests passed)
- `npm run build`

Existing Sass deprecation and bundle-budget warnings remain unchanged.

This pull request was created by an AI agent (OpenHands) on behalf of the user.