### PR TITLE
fix: enlarge server stats hover labels

### DIFF
--- a/src/pages/server-stats-page/server-stats-page.component.html
+++ b/src/pages/server-stats-page/server-stats-page.component.html
@@ -72,9 +72,9 @@
                     <line class="chart-hover-line" [attr.x1]="hoveredPointX()" y1="24" [attr.x2]="hoveredPointX()" y2="204" [attr.stroke]="chart.color"></line>
                     <circle class="chart-hover-dot" [attr.cx]="hoveredPointX()" [attr.cy]="chartPointY(hoveredPoint()!.sample, chart.key)" r="5" [attr.fill]="chart.color"></circle>
                     <g class="chart-tooltip" [attr.transform]="'translate(' + hoveredPointX() + ',' + hoveredPointY() + ')'" pointer-events="none">
-                      <rect x="-55" y="-30" width="110" height="24" rx="4"></rect>
-                      <text x="0" y="-20">{{ formatPercentage(valueFor(hoveredPoint()!.sample, chart.key)) }}</text>
-                      <text x="0" y="-10">{{ formatTimestamp(hoveredPoint()!.sample.recordedAt) }}</text>
+                      <rect x="-70" y="-48" width="140" height="42" rx="6"></rect>
+                      <text x="0" y="-32">{{ formatPercentage(valueFor(hoveredPoint()!.sample, chart.key)) }}</text>
+                      <text x="0" y="-16">{{ formatTimestamp(hoveredPoint()!.sample.recordedAt) }}</text>
                     </g>
                   }
                 </svg>

--- a/src/pages/server-stats-page/server-stats-page.component.scss
+++ b/src/pages/server-stats-page/server-stats-page.component.scss
@@ -34,7 +34,7 @@
 .chart-hover-line { stroke-dasharray: 3 4; stroke-opacity: .55; pointer-events: none; }
 .chart-hover-dot { stroke: #fff; stroke-width: 1.5; pointer-events: none; }
 .chart-tooltip rect { fill: rgba(15, 18, 22, .92); stroke: rgba(255, 255, 255, .18); }
-.chart-tooltip text { fill: #fff; font-size: 10px; text-anchor: middle; dominant-baseline: middle; }
+.chart-tooltip text { fill: #fff; font-size: 20px; text-anchor: middle; dominant-baseline: middle; }
 .chart-card__axis, .chart-card__footer { display: flex; justify-content: space-between; color: rgba(255, 255, 255, .35); font-size: .63rem; }
 .chart-card__axis { padding: 0 34px 12px 14px; }
 .chart-card__footer { border-top: 1px solid rgba(255, 255, 255, .07); padding: 11px 17px 13px; }

--- a/src/pages/server-stats-page/server-stats-page.component.ts
+++ b/src/pages/server-stats-page/server-stats-page.component.ts
@@ -132,12 +132,12 @@ export class ServerStatsPageComponent implements OnInit, OnDestroy {
 
     public hoveredPointX(): number {
         const point = this.hoveredPoint();
-        return point ? Math.max(60, Math.min(660, this.chartPointX(point.sample))) : 0;
+        return point ? Math.max(75, Math.min(621, this.chartPointX(point.sample))) : 0;
     }
 
     public hoveredPointY(): number {
         const point = this.hoveredPoint();
-        return point ? Math.max(36, this.chartPointY(point.sample, point.metric) - 8) : 0;
+        return point ? Math.max(56, this.chartPointY(point.sample, point.metric) - 8) : 0;
     }
 
     public samples(): Array<IStatHistorySample> {


### PR DESCRIPTION
## Summary

- double graph hover label text from 10px to 20px
- expand the tooltip background and spacing so the larger value and timestamp remain readable
- clamp the tooltip position farther from chart edges to prevent clipping

## Validation

- `npm run lint`
- `npm run test-ci` (36 tests passed)
- `npm run build`

Existing Sass deprecation and bundle-budget warnings remain unchanged.

This pull request was created by an AI agent (OpenHands) on behalf of the user.