### PR TITLE
fix: format qBitTorrent transfer rates

### DIFF
--- a/api/home-box-landing/HomeBoxLanding.Api/Features/QBitTorrent/QBitTorrentService.cs
+++ b/api/home-box-landing/HomeBoxLanding.Api/Features/QBitTorrent/QBitTorrentService.cs
@@ -33,6 +33,7 @@ public class QBitTorrentService : ISubscriber
 
         stats.TotalTorrents = torrents.Count;
         stats.UploadRate = torrents.Sum(torrent => torrent["upspeed"]?.Value<long>() ?? 0);
+        stats.DownloadRate = torrents.Sum(torrent => torrent["dlspeed"]?.Value<long>() ?? 0);
         stats.TotalLeeches = torrents.Sum(torrent => torrent["num_leechs"]?.Value<int>() ?? 0);
 
         return stats;
@@ -65,6 +66,7 @@ public class QBitTorrentService : ISubscriber
                                 Identifier = x.Identifier,
                                 TotalTorrents = x.TotalTorrents,
                                 UploadRate = x.UploadRate,
+                                DownloadRate = x.DownloadRate,
                                 TotalLeeches = x.TotalLeeches
                             }).ToList()
                         }

--- a/api/home-box-landing/HomeBoxLanding.Api/Features/QBitTorrent/Types/QBitTorrentStatsResponse.cs
+++ b/api/home-box-landing/HomeBoxLanding.Api/Features/QBitTorrent/Types/QBitTorrentStatsResponse.cs
@@ -5,5 +5,6 @@ public class QBitTorrentStatsResponse
     public Guid? Identifier { get; set; }
     public int TotalTorrents { get; set; }
     public long UploadRate { get; set; }
+    public long DownloadRate { get; set; }
     public int TotalLeeches { get; set; }
 }

--- a/src/components/custom-link/custom-details/qbittorrent-details/qbittorrent-details.component.html
+++ b/src/components/custom-link/custom-details/qbittorrent-details/qbittorrent-details.component.html
@@ -17,6 +17,12 @@
       </div>
       <div class="o-grid__col o-grid__col--equal">
         <div class="c-widget-stat qbittorrent-stat">
+          {{ formattedDownloadRate() }}
+          <div class="small">Download</div>
+        </div>
+      </div>
+      <div class="o-grid__col o-grid__col--equal">
+        <div class="c-widget-stat qbittorrent-stat">
           {{ stats()!.totalLeeches }}
           <div class="small">Leeches</div>
         </div>

--- a/src/components/custom-link/custom-details/qbittorrent-details/qbittorrent-details.component.spec.ts
+++ b/src/components/custom-link/custom-details/qbittorrent-details/qbittorrent-details.component.spec.ts
@@ -1,0 +1,46 @@
+import { Subject, of } from 'rxjs';
+import { QBitTorrentDetailsComponent } from './qbittorrent-details.component';
+import { QBitTorrentService } from '../../../../services/qbittorrent-service/qbittorrent.service';
+import { IQBitTorrentStats } from '../../../../services/qbittorrent-service/types/qbittorrent-stats.type';
+
+describe('QBitTorrentDetailsComponent', () => {
+    it('formats upload and download rates with lowercase kilobytes', () => {
+        const activities = new Subject<Array<IQBitTorrentStats>>();
+        const service = {
+            activities,
+            getStats: () => of({
+                identifier: 'qbittorrent-1',
+                totalTorrents: 12,
+                uploadRate: 10240,
+                downloadRate: 1048576,
+                totalLeeches: 4
+            }),
+            ngOnInit: vi.fn(),
+            ngOnDestroy: vi.fn()
+        } as unknown as QBitTorrentService;
+        const component = new QBitTorrentDetailsComponent(service);
+        component.item = { identifier: 'qbittorrent-1' } as any;
+
+        component.ngOnInit();
+
+        expect(component.formattedUploadRate()).toBe('10 kB/s');
+        expect(component.formattedDownloadRate()).toBe('1.0 MB/s');
+        expect(component.isLoading()).toBe(false);
+
+        activities.next([{
+            identifier: 'qbittorrent-1',
+            totalTorrents: 14,
+            uploadRate: 1024,
+            downloadRate: 1073741824,
+            totalLeeches: 5
+        }]);
+
+        expect(component.formattedUploadRate()).toBe('1.0 kB/s');
+        expect(component.formattedDownloadRate()).toBe('1.0 GB/s');
+        expect(component.stats()?.totalTorrents).toBe(14);
+
+        component.ngOnDestroy();
+        expect(service.ngOnInit).toHaveBeenCalledOnce();
+        expect(service.ngOnDestroy).toHaveBeenCalledOnce();
+    });
+});

--- a/src/components/custom-link/custom-details/qbittorrent-details/qbittorrent-details.component.ts
+++ b/src/components/custom-link/custom-details/qbittorrent-details/qbittorrent-details.component.ts
@@ -17,6 +17,7 @@ export class QBitTorrentDetailsComponent implements OnInit, OnDestroy {
 
     public stats: WritableSignal<IQBitTorrentStats | null> = signal<IQBitTorrentStats | null>(null);
     public formattedUploadRate: WritableSignal<string> = signal<string>('0 B/s');
+    public formattedDownloadRate: WritableSignal<string> = signal<string>('0 B/s');
     public isLoading: WritableSignal<boolean> = signal<boolean>(true);
 
     private readonly _destroy: Subject<void> = new Subject();
@@ -60,6 +61,7 @@ export class QBitTorrentDetailsComponent implements OnInit, OnDestroy {
     private updateStats(stats: IQBitTorrentStats): void {
         this.stats.set(stats);
         this.formattedUploadRate.set(this.formatBytesPerSecond(stats.uploadRate));
+        this.formattedDownloadRate.set(this.formatBytesPerSecond(stats.downloadRate));
     }
 
     private formatBytesPerSecond(bytesPerSecond: number): string {
@@ -67,7 +69,7 @@ export class QBitTorrentDetailsComponent implements OnInit, OnDestroy {
             return `${bytesPerSecond} B/s`;
         }
 
-        const units = ['KB/s', 'MB/s', 'GB/s'];
+        const units = ['kB/s', 'MB/s', 'GB/s'];
         const unitIndex = Math.min(Math.floor(Math.log(bytesPerSecond) / Math.log(1024)), units.length) - 1;
         const value = bytesPerSecond / Math.pow(1024, unitIndex + 1);
 

--- a/src/services/qbittorrent-service/qbittorrent.mapper.ts
+++ b/src/services/qbittorrent-service/qbittorrent.mapper.ts
@@ -7,6 +7,7 @@ export class QBitTorrentMapper {
             identifier: payload.Identifier,
             totalTorrents: payload.TotalTorrents ?? 0,
             uploadRate: payload.UploadRate ?? 0,
+            downloadRate: payload.DownloadRate ?? 0,
             totalLeeches: payload.TotalLeeches ?? 0
         };
     }

--- a/src/services/qbittorrent-service/types/qbittorrent-stats.type.ts
+++ b/src/services/qbittorrent-service/types/qbittorrent-stats.type.ts
@@ -2,5 +2,6 @@ export interface IQBitTorrentStats {
     identifier: string;
     totalTorrents: number;
     uploadRate: number;
+    downloadRate: number;
     totalLeeches: number;
 }

--- a/src/services/service-mappers.spec.ts
+++ b/src/services/service-mappers.spec.ts
@@ -313,11 +313,13 @@ describe('service mappers', () => {
             Identifier: 'qbittorrent-1',
             TotalTorrents: 12,
             UploadRate: 1048576,
+            DownloadRate: 2097152,
             TotalLeeches: 4
         }] } } })).toEqual([{
             identifier: 'qbittorrent-1',
             totalTorrents: 12,
             uploadRate: 1048576,
+            downloadRate: 2097152,
             totalLeeches: 4
         }]);
 
@@ -325,6 +327,7 @@ describe('service mappers', () => {
             identifier: 'qbittorrent-1',
             totalTorrents: 0,
             uploadRate: 0,
+            downloadRate: 0,
             totalLeeches: 0
         });
     });


### PR DESCRIPTION
## Summary
- add qBitTorrent download rate aggregation from `dlspeed`
- display upload and download rates in the widget
- format kilobyte rates as `kB/s` instead of `KB/s` while retaining adaptive MB/s and GB/s units
- add coverage for upload/download formatting and live activity updates

## Validation
- `npm run lint`
- `npm run test-ci` (39 tests passed)
- `npm run build`
- `dotnet build api/home-box-landing/HomeBoxLanding.sln --configuration Release`
- `dotnet test api/home-box-landing/HomeBoxLanding.sln --no-restore --configuration Release` (15 tests passed)

Existing Sass deprecation/budget notices and .NET compiler warnings remain.

This pull request was created by an AI agent (OpenHands) on behalf of the user.