### PR TITLE
feat: add database-backed settings page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 node_modules/
 dist/
 coverage/
-.openhands/memories/MEMORY.md
+.openhands/
 examples/*
 !examples/docker-compose.yml
 !examples/.env

--- a/.openhands/memory/2026-08-03.md
+++ b/.openhands/memory/2026-08-03.md
@@ -1,2 +1,0 @@
-
-- 2026-08-03: CI workflows were migrated from Node 20-era actions to Node 24-compatible releases: checkout v5, cache v5, Codecov v5, Docker login v4, and Renovate v46.2.1. The frontend lint job is enabled with `npm run lint`; lint, build, and 20 frontend tests pass.

--- a/.openhands/memory/MEMORY.md
+++ b/.openhands/memory/MEMORY.md
@@ -1,5 +1,0 @@
-# Project memory
-
-- GitHub push workaround: this repository's HTTPS `origin` may prompt for credentials even when the injected token is valid. Do not persist the token in Git config; push with an explicit temporary URL instead: `GIT_TERMINAL_PROMPT=0 git push "https://x-access-token:$GITHUB_PERSONAL_ACCESS_TOKEN@github.com/Citr0sCo/home-app.git" refs/heads/<branch>:refs/heads/<branch>`.
-- If local tracking is needed after an explicit-URL push, run `GIT_TERMINAL_PROMPT=0 git fetch origin <branch>:refs/remotes/origin/<branch>` followed by `git branch --set-upstream-to=origin/<branch> <branch>`.
-- When the dedicated PR tool is unavailable, use the GitHub REST API with the injected bearer token to create the PR; use `convertPullRequestToDraft` through GraphQL if the PR must remain draft.

--- a/api/home-box-landing/HomeBoxLanding.Api/Data/DatabaseContext.cs
+++ b/api/home-box-landing/HomeBoxLanding.Api/Data/DatabaseContext.cs
@@ -5,6 +5,7 @@ using HomeBoxLanding.Api.Features.FuelPricePoller.Types;
 using HomeBoxLanding.Api.Features.Links.Types;
 using HomeBoxLanding.Api.Features.Notepad.Types;
 using HomeBoxLanding.Api.Features.Stats.Types;
+using HomeBoxLanding.Api.Features.Settings.Types;
 using Microsoft.EntityFrameworkCore;
 
 namespace HomeBoxLanding.Api.Data;
@@ -26,6 +27,7 @@ public class DatabaseContext : DbContext
     public DbSet<DockerBuildRecord> DockerBuilds { get; set; }
     public DbSet<NotepadRecord> Notepads { get; set; }
     public DbSet<ServerStatsHistoryRecord> ServerStatsHistory { get; set; }
+    public DbSet<SettingRecord> Settings { get; set; }
 
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {

--- a/api/home-box-landing/HomeBoxLanding.Api/Features/Builds/BuildsService.cs
+++ b/api/home-box-landing/HomeBoxLanding.Api/Features/Builds/BuildsService.cs
@@ -1,3 +1,4 @@
+using HomeBoxLanding.Api.Features.Settings;
 using HomeBoxLanding.Api.Core.Shell;
 using HomeBoxLanding.Api.Features.Builds.Types;
 using HomeBoxLanding.Api.Features.WebSockets.Types;
@@ -33,7 +34,7 @@ public class BuildsService
 
     public async Task Update()
     {
-        var rootFolder = Environment.GetEnvironmentVariable("ASPNETCORE_UPDATE_SCRIPT_ROOT");
+        var rootFolder = SettingsService.ResolveValue("ASPNETCORE_UPDATE_SCRIPT_ROOT");
 
         var logFile = _shellService.Run("echo output_$(date +%Y-%m-%d-%H-%M).log")
             .TrimEnd(Environment.NewLine.ToCharArray());

--- a/api/home-box-landing/HomeBoxLanding.Api/Features/Configs/ConfigsController.cs
+++ b/api/home-box-landing/HomeBoxLanding.Api/Features/Configs/ConfigsController.cs
@@ -1,3 +1,4 @@
+using HomeBoxLanding.Api.Features.Settings;
 using Microsoft.AspNetCore.Mvc;
 
 namespace HomeBoxLanding.Api.Features.Configs;
@@ -6,13 +7,20 @@ namespace HomeBoxLanding.Api.Features.Configs;
 [Route("api/configs")]
 public class ConfigsController : ControllerBase
 {
+    private readonly SettingsService _settingsService;
+
+    public ConfigsController(SettingsService settingsService)
+    {
+        _settingsService = settingsService;
+    }
+
     [HttpGet]
     public GetAllConfigsResponse GetAll()
     {
         return new GetAllConfigsResponse
         {
-            WeatherApiKey = Environment.GetEnvironmentVariable("ASPNETCORE_WEATHER_API_KEY"),
-            MapsApiKey = Environment.GetEnvironmentVariable("ASPNETCORE_MAPS_API_KEY")
+            WeatherApiKey = _settingsService.Resolve("ASPNETCORE_WEATHER_API_KEY"),
+            MapsApiKey = _settingsService.Resolve("ASPNETCORE_MAPS_API_KEY")
         };
     }
 

--- a/api/home-box-landing/HomeBoxLanding.Api/Features/FuelPricePoller/FuelPricePoller.cs
+++ b/api/home-box-landing/HomeBoxLanding.Api/Features/FuelPricePoller/FuelPricePoller.cs
@@ -1,3 +1,4 @@
+using HomeBoxLanding.Api.Features.Settings;
 ﻿using System.Net.Http.Headers;
 using HomeBoxLanding.Api.Core.Events.Types;
 using HomeBoxLanding.Api.Features.FuelPricePoller.Types;
@@ -36,8 +37,8 @@ public class FuelPricePoller : ISubscriber
         var request = new FormUrlEncodedContent(new List<KeyValuePair<string, string>>
         {
             new("grant_type", "client_credentials"),
-            new("client_id", Environment.GetEnvironmentVariable("ASPNETCORE_FUEL_FINDER_CLIENT_ID")!),
-            new("client_secret", Environment.GetEnvironmentVariable("ASPNETCORE_FUEL_FINDER_CLIENT_SECRET")!),
+            new("client_id", SettingsService.ResolveValue("ASPNETCORE_FUEL_FINDER_CLIENT_ID")!),
+            new("client_secret", SettingsService.ResolveValue("ASPNETCORE_FUEL_FINDER_CLIENT_SECRET")!),
             new("scope", "fuelfinder.read")
         });
         

--- a/api/home-box-landing/HomeBoxLanding.Api/Features/Lidarr/LidarrService.cs
+++ b/api/home-box-landing/HomeBoxLanding.Api/Features/Lidarr/LidarrService.cs
@@ -1,3 +1,4 @@
+using HomeBoxLanding.Api.Features.Settings;
 using HomeBoxLanding.Api.Core.Events.Types;
 using HomeBoxLanding.Api.Features.Lidarr.Types;
 using HomeBoxLanding.Api.Features.Links;
@@ -11,12 +12,10 @@ public class LidarrService : ISubscriber
 {
     private readonly LinksService _linksService;
     private bool _isStarted = false;
-    private string API_KEY;
 
     public LidarrService(LinksService linksService)
     {
         _linksService = linksService;
-        API_KEY = Environment.GetEnvironmentVariable("ASPNETCORE_LIDARR_API_KEY");
     }
 
     public LidarrActivityResponse GetActivity()
@@ -52,7 +51,7 @@ public class LidarrService : ISubscriber
     {
         var httpClient = new HttpClient();
         httpClient.Timeout = TimeSpan.FromSeconds(20);
-        var result = httpClient.GetAsync($"{link.Url}api/v1/artist?apiKey={API_KEY}").Result;
+        var result = httpClient.GetAsync($"{link.Url}api/v1/artist?apiKey={SettingsService.ResolveValue("ASPNETCORE_LIDARR_API_KEY")}").Result;
         var response = result.Content.ReadAsStringAsync().Result;
 
         List<LidarrTrack>? parsedResponse;
@@ -73,7 +72,7 @@ public class LidarrService : ISubscriber
     {
         var httpClient = new HttpClient();
         httpClient.Timeout = TimeSpan.FromSeconds(20);
-        var result = httpClient.GetAsync($"{link.Url}api/v1/queue?apiKey={API_KEY}").Result;
+        var result = httpClient.GetAsync($"{link.Url}api/v1/queue?apiKey={SettingsService.ResolveValue("ASPNETCORE_LIDARR_API_KEY")}").Result;
         var response = result.Content.ReadAsStringAsync().Result;
 
         LidarrQueue? parsedResponse;
@@ -94,7 +93,7 @@ public class LidarrService : ISubscriber
     {
         var httpClient = new HttpClient();
         httpClient.Timeout = TimeSpan.FromSeconds(20);
-        var result = httpClient.GetAsync($"{link.Url}api/v1/health?apiKey={API_KEY}").Result;
+        var result = httpClient.GetAsync($"{link.Url}api/v1/health?apiKey={SettingsService.ResolveValue("ASPNETCORE_LIDARR_API_KEY")}").Result;
         var response = result.Content.ReadAsStringAsync().Result;
 
         List<LidarrHealth>? parsedResponse;

--- a/api/home-box-landing/HomeBoxLanding.Api/Features/Links/LinksService.cs
+++ b/api/home-box-landing/HomeBoxLanding.Api/Features/Links/LinksService.cs
@@ -1,3 +1,4 @@
+using HomeBoxLanding.Api.Features.Settings;
 using HomeBoxLanding.Api.Core.Types;
 using HomeBoxLanding.Api.Features.Links.Types;
 using Minio;
@@ -18,13 +19,13 @@ public class LinksService
         _linksRepository = linksRepository;
         
         _minioClient = new MinioClient()
-            .WithEndpoint(Environment.GetEnvironmentVariable("ASPNETCORE_MINIO_ENDPOINT"))
-            .WithCredentials(Environment.GetEnvironmentVariable("ASPNETCORE_MINIO_ACCESS_KEY"), Environment.GetEnvironmentVariable("ASPNETCORE_MINIO_SECRET_KEY"))
+            .WithEndpoint(SettingsService.ResolveValue("ASPNETCORE_MINIO_ENDPOINT"))
+            .WithCredentials(SettingsService.ResolveValue("ASPNETCORE_MINIO_ACCESS_KEY"), SettingsService.ResolveValue("ASPNETCORE_MINIO_SECRET_KEY"))
             .WithSSL()
             .Build();
 
-        _cdnUrl = Environment.GetEnvironmentVariable("ASPNETCORE_MINIO_CDN_URL");
-        _bucketName = Environment.GetEnvironmentVariable("ASPNETCORE_MINIO_BUCKET_NAME");
+        _cdnUrl = SettingsService.ResolveValue("ASPNETCORE_MINIO_CDN_URL");
+        _bucketName = SettingsService.ResolveValue("ASPNETCORE_MINIO_BUCKET_NAME");
     }
 
     public LinksResponse GetAllLinks()

--- a/api/home-box-landing/HomeBoxLanding.Api/Features/PiHole/PiHoleService.cs
+++ b/api/home-box-landing/HomeBoxLanding.Api/Features/PiHole/PiHoleService.cs
@@ -1,3 +1,4 @@
+using HomeBoxLanding.Api.Features.Settings;
 using HomeBoxLanding.Api.Core.Events.Types;
 using HomeBoxLanding.Api.Features.Links;
 using HomeBoxLanding.Api.Features.PiHole.Types;
@@ -63,7 +64,7 @@ public class PiHoleService : ISubscriber
     
     private string? Authenticate(string baseUrl)
     {
-        var apiKey = Environment.GetEnvironmentVariable("ASPNETCORE_PIHOLE_API_KEY");
+        var apiKey = SettingsService.ResolveValue("ASPNETCORE_PIHOLE_API_KEY");
         
         var request = new PiHoleAuthenticateRequest()
         {

--- a/api/home-box-landing/HomeBoxLanding.Api/Features/Plex/PlexService.cs
+++ b/api/home-box-landing/HomeBoxLanding.Api/Features/Plex/PlexService.cs
@@ -1,3 +1,4 @@
+using HomeBoxLanding.Api.Features.Settings;
 using HomeBoxLanding.Api.Core.Events.Types;
 using HomeBoxLanding.Api.Features.Links;
 using HomeBoxLanding.Api.Features.Plex.Types;
@@ -10,12 +11,10 @@ public class PlexService : ISubscriber
 {
     private readonly LinksService _linksService;
     private bool _isStarted = false;
-    private string API_KEY;
 
     public PlexService(LinksService linksService)
     {
         _linksService = linksService;
-        API_KEY = Environment.GetEnvironmentVariable("ASPNETCORE_TAUTULLI_API_KEY");
     }
 
     public PlexActivityResponse GetActivity()
@@ -29,7 +28,7 @@ public class PlexService : ISubscriber
         
         var httpClient = new HttpClient();
         httpClient.Timeout = TimeSpan.FromSeconds(2);
-        var result = httpClient.GetAsync($"http://{link.Host}:{link.Port}/api/v2?apikey={API_KEY}&cmd=get_activity").Result;
+        var result = httpClient.GetAsync($"http://{link.Host}:{link.Port}/api/v2?apikey={SettingsService.ResolveValue("ASPNETCORE_TAUTULLI_API_KEY")}&cmd=get_activity").Result;
         var response = result.Content.ReadAsStringAsync().Result;
             
         return JsonConvert.DeserializeObject<PlexActivityResponse>(response) ?? new PlexActivityResponse();

--- a/api/home-box-landing/HomeBoxLanding.Api/Features/Radarr/RadarrService.cs
+++ b/api/home-box-landing/HomeBoxLanding.Api/Features/Radarr/RadarrService.cs
@@ -1,3 +1,4 @@
+using HomeBoxLanding.Api.Features.Settings;
 using HomeBoxLanding.Api.Core.Events.Types;
 using HomeBoxLanding.Api.Features.Links;
 using HomeBoxLanding.Api.Features.Links.Types;
@@ -11,12 +12,10 @@ public class RadarrService : ISubscriber
 {
     private readonly LinksService _linksService;
     private bool _isStarted = false;
-    private string API_KEY;
 
     public RadarrService(LinksService linksService)
     {
         _linksService = linksService;
-        API_KEY = Environment.GetEnvironmentVariable("ASPNETCORE_RADARR_API_KEY");
     }
 
     public RadarrActivityResponse GetActivity()
@@ -52,7 +51,7 @@ public class RadarrService : ISubscriber
     {
         var httpClient = new HttpClient();
         httpClient.Timeout = TimeSpan.FromSeconds(20);
-        var result = httpClient.GetAsync($"{link.Url}api/v3/movie?apiKey={API_KEY}").Result;
+        var result = httpClient.GetAsync($"{link.Url}api/v3/movie?apiKey={SettingsService.ResolveValue("ASPNETCORE_RADARR_API_KEY")}").Result;
         var response = result.Content.ReadAsStringAsync().Result;
 
         List<RadarrMovie>? parsedResponse;
@@ -73,7 +72,7 @@ public class RadarrService : ISubscriber
     {
         var httpClient = new HttpClient();
         httpClient.Timeout = TimeSpan.FromSeconds(20);
-        var result = httpClient.GetAsync($"{link.Url}api/v3/queue?apiKey={API_KEY}").Result;
+        var result = httpClient.GetAsync($"{link.Url}api/v3/queue?apiKey={SettingsService.ResolveValue("ASPNETCORE_RADARR_API_KEY")}").Result;
         var response = result.Content.ReadAsStringAsync().Result;
 
         RadarrQueue? parsedResponse;
@@ -94,7 +93,7 @@ public class RadarrService : ISubscriber
     {
         var httpClient = new HttpClient();
         httpClient.Timeout = TimeSpan.FromSeconds(20);
-        var result = httpClient.GetAsync($"{link.Url}api/v3/health?apiKey={API_KEY}").Result;
+        var result = httpClient.GetAsync($"{link.Url}api/v3/health?apiKey={SettingsService.ResolveValue("ASPNETCORE_RADARR_API_KEY")}").Result;
         var response = result.Content.ReadAsStringAsync().Result;
 
         List<RadarrHealth>? parsedResponse;

--- a/api/home-box-landing/HomeBoxLanding.Api/Features/Readarr/ReadarrService.cs
+++ b/api/home-box-landing/HomeBoxLanding.Api/Features/Readarr/ReadarrService.cs
@@ -1,3 +1,4 @@
+using HomeBoxLanding.Api.Features.Settings;
 using HomeBoxLanding.Api.Core.Events.Types;
 using HomeBoxLanding.Api.Features.Links;
 using HomeBoxLanding.Api.Features.Links.Types;
@@ -11,12 +12,10 @@ public class ReadarrService : ISubscriber
 {
     private readonly LinksService _linksService;
     private bool _isStarted = false;
-    private string API_KEY;
 
     public ReadarrService(LinksService linksService)
     {
         _linksService = linksService;
-        API_KEY = Environment.GetEnvironmentVariable("ASPNETCORE_READARR_API_KEY");
     }
 
     public ReadarrActivityResponse GetActivity()
@@ -52,7 +51,7 @@ public class ReadarrService : ISubscriber
     {
         var httpClient = new HttpClient();
         httpClient.Timeout = TimeSpan.FromSeconds(20);
-        var result = httpClient.GetAsync($"{link.Url}api/v1/author?apiKey={API_KEY}").Result;
+        var result = httpClient.GetAsync($"{link.Url}api/v1/author?apiKey={SettingsService.ResolveValue("ASPNETCORE_READARR_API_KEY")}").Result;
         var response = result.Content.ReadAsStringAsync().Result;
 
         List<ReadarrTrack>? parsedResponse;
@@ -73,7 +72,7 @@ public class ReadarrService : ISubscriber
     {
         var httpClient = new HttpClient();
         httpClient.Timeout = TimeSpan.FromSeconds(20);
-        var result = httpClient.GetAsync($"{link.Url}api/v1/queue?apiKey={API_KEY}").Result;
+        var result = httpClient.GetAsync($"{link.Url}api/v1/queue?apiKey={SettingsService.ResolveValue("ASPNETCORE_READARR_API_KEY")}").Result;
         var response = result.Content.ReadAsStringAsync().Result;
 
         ReadarrQueue? parsedResponse;
@@ -94,7 +93,7 @@ public class ReadarrService : ISubscriber
     {
         var httpClient = new HttpClient();
         httpClient.Timeout = TimeSpan.FromSeconds(20);
-        var result = httpClient.GetAsync($"{link.Url}api/v1/health?apiKey={API_KEY}").Result;
+        var result = httpClient.GetAsync($"{link.Url}api/v1/health?apiKey={SettingsService.ResolveValue("ASPNETCORE_READARR_API_KEY")}").Result;
         var response = result.Content.ReadAsStringAsync().Result;
 
         List<ReadarrHealth>? parsedResponse;

--- a/api/home-box-landing/HomeBoxLanding.Api/Features/Settings/SettingsController.cs
+++ b/api/home-box-landing/HomeBoxLanding.Api/Features/Settings/SettingsController.cs
@@ -1,0 +1,22 @@
+using HomeBoxLanding.Api.Features.Settings.Types;
+using Microsoft.AspNetCore.Mvc;
+
+namespace HomeBoxLanding.Api.Features.Settings;
+
+[ApiController]
+[Route("api/settings")]
+public class SettingsController : ControllerBase
+{
+    private readonly SettingsService _service;
+
+    public SettingsController(SettingsService service)
+    {
+        _service = service;
+    }
+
+    [HttpGet]
+    public SettingsResponse GetAll() => _service.GetAll();
+
+    [HttpPut]
+    public SettingsResponse Update([FromBody] UpdateSettingsRequest request) => _service.Update(request);
+}

--- a/api/home-box-landing/HomeBoxLanding.Api/Features/Settings/SettingsService.cs
+++ b/api/home-box-landing/HomeBoxLanding.Api/Features/Settings/SettingsService.cs
@@ -1,0 +1,111 @@
+using HomeBoxLanding.Api.Data;
+using HomeBoxLanding.Api.Features.Settings.Types;
+using Microsoft.EntityFrameworkCore;
+
+namespace HomeBoxLanding.Api.Features.Settings;
+
+public class SettingsService
+{
+    private static readonly IReadOnlyList<SettingDefinition> Definitions = new List<SettingDefinition>
+    {
+        new() { Key = "weatherApiKey", EnvironmentVariable = "ASPNETCORE_WEATHER_API_KEY", Label = "Weather API key", Description = "OpenWeatherMap API key used for the weather widget.", IsSecret = true },
+        new() { Key = "mapsApiKey", EnvironmentVariable = "ASPNETCORE_MAPS_API_KEY", Label = "Maps API key", Description = "Mapbox access token used for map widgets.", IsSecret = true },
+        new() { Key = "tautulliApiKey", EnvironmentVariable = "ASPNETCORE_TAUTULLI_API_KEY", Label = "Tautulli API key", Description = "API key shared by the Tautulli and Plex widgets.", IsSecret = true },
+        new() { Key = "radarrApiKey", EnvironmentVariable = "ASPNETCORE_RADARR_API_KEY", Label = "Radarr API key", Description = "API key used by the Radarr widget.", IsSecret = true },
+        new() { Key = "sonarrApiKey", EnvironmentVariable = "ASPNETCORE_SONARR_API_KEY", Label = "Sonarr API key", Description = "API key used by the Sonarr widget.", IsSecret = true },
+        new() { Key = "lidarrApiKey", EnvironmentVariable = "ASPNETCORE_LIDARR_API_KEY", Label = "Lidarr API key", Description = "API key used by the Lidarr widget.", IsSecret = true },
+        new() { Key = "readarrApiKey", EnvironmentVariable = "ASPNETCORE_READARR_API_KEY", Label = "Readarr API key", Description = "API key used by the Readarr widget.", IsSecret = true },
+        new() { Key = "piHoleApiKey", EnvironmentVariable = "ASPNETCORE_PIHOLE_API_KEY", Label = "Pi-hole API key", Description = "Password or API key used by the Pi-hole widget.", IsSecret = true },
+        new() { Key = "uptimeKumaApiKey", EnvironmentVariable = "ASPNETCORE_UPTIME_KUMA_API_KEY", Label = "Uptime Kuma API key", Description = "API key used to authenticate with Uptime Kuma metrics.", IsSecret = true },
+        new() { Key = "fuelFinderClientId", EnvironmentVariable = "ASPNETCORE_FUEL_FINDER_CLIENT_ID", Label = "Fuel Finder client ID", Description = "Client ID used to retrieve UK fuel prices.", IsSecret = true },
+        new() { Key = "fuelFinderClientSecret", EnvironmentVariable = "ASPNETCORE_FUEL_FINDER_CLIENT_SECRET", Label = "Fuel Finder client secret", Description = "Client secret used to retrieve UK fuel prices.", IsSecret = true },
+        new() { Key = "updateScriptRoot", EnvironmentVariable = "ASPNETCORE_UPDATE_SCRIPT_ROOT", Label = "Update script root", Description = "Host path containing the Docker update script.", IsSecret = false },
+        new() { Key = "minioEndpoint", EnvironmentVariable = "ASPNETCORE_MINIO_ENDPOINT", Label = "MinIO endpoint", Description = "MinIO host and port used for uploaded link icons.", IsSecret = false },
+        new() { Key = "minioAccessKey", EnvironmentVariable = "ASPNETCORE_MINIO_ACCESS_KEY", Label = "MinIO access key", Description = "Access key used for uploaded link icons.", IsSecret = true },
+        new() { Key = "minioSecretKey", EnvironmentVariable = "ASPNETCORE_MINIO_SECRET_KEY", Label = "MinIO secret key", Description = "Secret key used for uploaded link icons.", IsSecret = true },
+        new() { Key = "minioCdnUrl", EnvironmentVariable = "ASPNETCORE_MINIO_CDN_URL", Label = "MinIO CDN URL", Description = "Public CDN URL for uploaded link icons.", IsSecret = false },
+        new() { Key = "minioBucketName", EnvironmentVariable = "ASPNETCORE_MINIO_BUCKET_NAME", Label = "MinIO bucket name", Description = "Bucket used for uploaded link icons.", IsSecret = false }
+    };
+
+    private readonly DatabaseContext _databaseContext;
+
+    public SettingsService(DatabaseContext databaseContext)
+    {
+        _databaseContext = databaseContext;
+    }
+
+    public string? Resolve(string environmentVariable)
+    {
+        var storedValue = _databaseContext.Set<SettingRecord>()
+            .AsNoTracking()
+            .FirstOrDefault(setting => setting.Key == environmentVariable)?.Value;
+
+        return string.IsNullOrWhiteSpace(storedValue)
+            ? Environment.GetEnvironmentVariable(environmentVariable)
+            : storedValue;
+    }
+
+    public static string? ResolveValue(string environmentVariable)
+    {
+        using var databaseContext = new DatabaseContext();
+        return new SettingsService(databaseContext).Resolve(environmentVariable);
+    }
+
+    public SettingsResponse GetAll()
+    {
+        var storedSettings = _databaseContext.Set<SettingRecord>()
+            .AsNoTracking()
+            .ToDictionary(setting => setting.Key, setting => setting.Value);
+
+        return new SettingsResponse
+        {
+            Settings = Definitions.Select(definition =>
+            {
+                var value = storedSettings.TryGetValue(definition.EnvironmentVariable, out var storedValue) && !string.IsNullOrWhiteSpace(storedValue)
+                    ? storedValue
+                    : Environment.GetEnvironmentVariable(definition.EnvironmentVariable) ?? string.Empty;
+
+                return new Setting
+                {
+                    Key = definition.Key,
+                    EnvironmentVariable = definition.EnvironmentVariable,
+                    Label = definition.Label,
+                    Description = definition.Description,
+                    Value = value,
+                    IsSecret = definition.IsSecret,
+                    IsConfigured = !string.IsNullOrWhiteSpace(value)
+                };
+            }).ToList()
+        };
+    }
+
+    public SettingsResponse Update(UpdateSettingsRequest request)
+    {
+        var validKeys = Definitions.Select(definition => definition.Key).ToHashSet(StringComparer.Ordinal);
+        var definitionsByKey = Definitions.ToDictionary(definition => definition.Key, StringComparer.Ordinal);
+
+        foreach (var setting in request.Settings.Where(setting => validKeys.Contains(setting.Key)))
+        {
+            var environmentVariable = definitionsByKey[setting.Key].EnvironmentVariable;
+            var record = _databaseContext.Set<SettingRecord>().Find(environmentVariable);
+            var value = setting.Value?.Trim() ?? string.Empty;
+
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                if (record is not null)
+                    _databaseContext.Set<SettingRecord>().Remove(record);
+            }
+            else if (record is null)
+            {
+                _databaseContext.Set<SettingRecord>().Add(new SettingRecord { Key = environmentVariable, Value = value });
+            }
+            else
+            {
+                record.Value = value;
+            }
+        }
+
+        _databaseContext.SaveChanges();
+        return GetAll();
+    }
+}

--- a/api/home-box-landing/HomeBoxLanding.Api/Features/Settings/Types/SettingDefinition.cs
+++ b/api/home-box-landing/HomeBoxLanding.Api/Features/Settings/Types/SettingDefinition.cs
@@ -1,0 +1,10 @@
+namespace HomeBoxLanding.Api.Features.Settings.Types;
+
+public class SettingDefinition
+{
+    public string Key { get; init; } = string.Empty;
+    public string EnvironmentVariable { get; init; } = string.Empty;
+    public string Label { get; init; } = string.Empty;
+    public string Description { get; init; } = string.Empty;
+    public bool IsSecret { get; init; }
+}

--- a/api/home-box-landing/HomeBoxLanding.Api/Features/Settings/Types/SettingRecord.cs
+++ b/api/home-box-landing/HomeBoxLanding.Api/Features/Settings/Types/SettingRecord.cs
@@ -1,0 +1,10 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace HomeBoxLanding.Api.Features.Settings.Types;
+
+public class SettingRecord
+{
+    [Key]
+    public string Key { get; set; } = string.Empty;
+    public string Value { get; set; } = string.Empty;
+}

--- a/api/home-box-landing/HomeBoxLanding.Api/Features/Settings/Types/SettingsResponse.cs
+++ b/api/home-box-landing/HomeBoxLanding.Api/Features/Settings/Types/SettingsResponse.cs
@@ -1,0 +1,17 @@
+namespace HomeBoxLanding.Api.Features.Settings.Types;
+
+public class SettingsResponse
+{
+    public List<Setting> Settings { get; set; } = new();
+}
+
+public class Setting
+{
+    public string Key { get; set; } = string.Empty;
+    public string EnvironmentVariable { get; set; } = string.Empty;
+    public string Label { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public string Value { get; set; } = string.Empty;
+    public bool IsSecret { get; set; }
+    public bool IsConfigured { get; set; }
+}

--- a/api/home-box-landing/HomeBoxLanding.Api/Features/Settings/Types/UpdateSettingsRequest.cs
+++ b/api/home-box-landing/HomeBoxLanding.Api/Features/Settings/Types/UpdateSettingsRequest.cs
@@ -1,0 +1,12 @@
+namespace HomeBoxLanding.Api.Features.Settings.Types;
+
+public class UpdateSettingsRequest
+{
+    public List<SettingValue> Settings { get; set; } = new();
+}
+
+public class SettingValue
+{
+    public string Key { get; set; } = string.Empty;
+    public string? Value { get; set; }
+}

--- a/api/home-box-landing/HomeBoxLanding.Api/Features/Sonarr/SonarrService.cs
+++ b/api/home-box-landing/HomeBoxLanding.Api/Features/Sonarr/SonarrService.cs
@@ -1,3 +1,4 @@
+using HomeBoxLanding.Api.Features.Settings;
 using HomeBoxLanding.Api.Core.Events.Types;
 using HomeBoxLanding.Api.Features.Links;
 using HomeBoxLanding.Api.Features.Links.Types;
@@ -11,12 +12,10 @@ public class SonarrService : ISubscriber
 {
     private readonly LinksService _linksService;
     private bool _isStarted = false;
-    private string API_KEY;
 
     public SonarrService(LinksService linksService)
     {
         _linksService = linksService;
-        API_KEY = Environment.GetEnvironmentVariable("ASPNETCORE_SONARR_API_KEY");
     }
 
     public SonarrActivityResponse GetActivity()
@@ -54,7 +53,7 @@ public class SonarrService : ISubscriber
     {
         var httpClient = new HttpClient();
         httpClient.Timeout = TimeSpan.FromSeconds(20);
-        var result = httpClient.GetAsync($"{link.Url}api/v3/series?apiKey={API_KEY}").Result;
+        var result = httpClient.GetAsync($"{link.Url}api/v3/series?apiKey={SettingsService.ResolveValue("ASPNETCORE_SONARR_API_KEY")}").Result;
         var response = result.Content.ReadAsStringAsync().Result;
 
         List<SonarrSeries>? parsedResponse;
@@ -75,7 +74,7 @@ public class SonarrService : ISubscriber
     {
         var httpClient = new HttpClient();
         httpClient.Timeout = TimeSpan.FromSeconds(20);
-        var result = httpClient.GetAsync($"{link.Url}api/v3/wanted/missing?apiKey={API_KEY}").Result;
+        var result = httpClient.GetAsync($"{link.Url}api/v3/wanted/missing?apiKey={SettingsService.ResolveValue("ASPNETCORE_SONARR_API_KEY")}").Result;
         var response = result.Content.ReadAsStringAsync().Result;
 
         SonarrMissing? parsedResponse;
@@ -96,7 +95,7 @@ public class SonarrService : ISubscriber
     {
         var httpClient = new HttpClient();
         httpClient.Timeout = TimeSpan.FromSeconds(20);
-        var result = httpClient.GetAsync($"{link.Url}api/v3/queue?apiKey={API_KEY}").Result;
+        var result = httpClient.GetAsync($"{link.Url}api/v3/queue?apiKey={SettingsService.ResolveValue("ASPNETCORE_SONARR_API_KEY")}").Result;
         var response = result.Content.ReadAsStringAsync().Result;
 
         SonarrQueue? parsedResponse;
@@ -117,7 +116,7 @@ public class SonarrService : ISubscriber
     {
         var httpClient = new HttpClient();
         httpClient.Timeout = TimeSpan.FromSeconds(20);
-        var result = httpClient.GetAsync($"{link.Url}api/v3/health?apiKey={API_KEY}").Result;
+        var result = httpClient.GetAsync($"{link.Url}api/v3/health?apiKey={SettingsService.ResolveValue("ASPNETCORE_SONARR_API_KEY")}").Result;
         var response = result.Content.ReadAsStringAsync().Result;
 
         List<SonarrHealth>? parsedResponse;

--- a/api/home-box-landing/HomeBoxLanding.Api/Features/Tautulli/TautulliService.cs
+++ b/api/home-box-landing/HomeBoxLanding.Api/Features/Tautulli/TautulliService.cs
@@ -1,3 +1,4 @@
+using HomeBoxLanding.Api.Features.Settings;
 using HomeBoxLanding.Api.Core.Events.Types;
 using HomeBoxLanding.Api.Features.Links;
 using HomeBoxLanding.Api.Features.Tautulli.Types;
@@ -52,7 +53,7 @@ public class TautulliService : ISubscriber
     {
         try
         {
-            var apiKey = Environment.GetEnvironmentVariable("ASPNETCORE_TAUTULLI_API_KEY");
+            var apiKey = SettingsService.ResolveValue("ASPNETCORE_TAUTULLI_API_KEY");
             var url = $"{baseUrl}/api/v2?apikey={Uri.EscapeDataString(apiKey ?? string.Empty)}&cmd={command}";
             using var httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(20) };
             using var result = httpClient.GetAsync(url).Result;

--- a/api/home-box-landing/HomeBoxLanding.Api/Features/UptimeKuma/UptimeKumaService.cs
+++ b/api/home-box-landing/HomeBoxLanding.Api/Features/UptimeKuma/UptimeKumaService.cs
@@ -1,3 +1,4 @@
+using HomeBoxLanding.Api.Features.Settings;
 using System.Net.Http.Headers;
 using System.Text;
 using Fennel.CSharp;
@@ -27,7 +28,7 @@ public class UptimeKumaService : ISubscriber
             return new UptimeKumaActivityResponse();
 
         var baseUrl = $"http://{link.Host}:{link.Port}";
-        var apiKey = Environment.GetEnvironmentVariable("ASPNETCORE_UPTIME_KUMA_API_KEY");
+        var apiKey = SettingsService.ResolveValue("ASPNETCORE_UPTIME_KUMA_API_KEY");
         var credentials = Convert.ToBase64String(Encoding.UTF8.GetBytes($":{apiKey}"));
         
         var httpClient = new HttpClient();

--- a/api/home-box-landing/HomeBoxLanding.Api/Migrations/20260812110441_AddSettings.Designer.cs
+++ b/api/home-box-landing/HomeBoxLanding.Api/Migrations/20260812110441_AddSettings.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using HomeBoxLanding.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace HomeBoxLanding.Api.Migrations
 {
     [DbContext(typeof(DatabaseContext))]
-    partial class DatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20260812110441_AddSettings")]
+    partial class AddSettings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.11");

--- a/api/home-box-landing/HomeBoxLanding.Api/Migrations/20260812110441_AddSettings.cs
+++ b/api/home-box-landing/HomeBoxLanding.Api/Migrations/20260812110441_AddSettings.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace HomeBoxLanding.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSettings : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Settings",
+                columns: table => new
+                {
+                    Key = table.Column<string>(type: "TEXT", nullable: false),
+                    Value = table.Column<string>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Settings", x => x.Key);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Settings");
+        }
+    }
+}

--- a/api/home-box-landing/HomeBoxLanding.Api/Program.cs
+++ b/api/home-box-landing/HomeBoxLanding.Api/Program.cs
@@ -11,10 +11,10 @@ using HomeBoxLanding.Api.Features.Radarr;
 using HomeBoxLanding.Api.Features.Readarr;
 using HomeBoxLanding.Api.Features.Sonarr;
 using HomeBoxLanding.Api.Features.Stats;
+using HomeBoxLanding.Api.Features.Settings;
 using HomeBoxLanding.Api.Features.Tautulli;
 using HomeBoxLanding.Api.Features.UptimeKuma;
 using Microsoft.EntityFrameworkCore;
-using Minio;
 using WebSocketManager = HomeBoxLanding.Api.Features.WebSockets.WebSocketManager;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -28,19 +28,13 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 builder.Services.AddHttpClient();
 builder.Services.AddMemoryCache();
+builder.Services.AddScoped<SettingsService>();
 
 builder.Services.AddHttpClient("IgnoreSslClient").ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
 {
     CheckCertificateRevocationList = false,
     ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
 });
-
-var endpoint = Environment.GetEnvironmentVariable("ASPNETCORE_MINIO_ENDPOINT");
-var accessKey = Environment.GetEnvironmentVariable("ASPNETCORE_MINIO_ACCESS_KEY");
-var secretKey = Environment.GetEnvironmentVariable("ASPNETCORE_MINIO_SECRET_KEY");
-builder.Services.AddMinio(configureClient => configureClient
-    .WithEndpoint(endpoint)
-    .WithCredentials(accessKey, secretKey));
 
 var app = builder.Build();
 

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -5,6 +5,7 @@ import { FuelPricesPageComponent } from '../pages/fuel-prices-page/fuel-prices-p
 import { UpdateDockerAppsPageComponent } from '../pages/update-docker-apps-page/update-docker-apps-page.component';
 import { NotepadPageComponent } from '../pages/notepad-page/notepad-page.component';
 import { ServerStatsPageComponent } from '../pages/server-stats-page/server-stats-page.component';
+import { SettingsPageComponent } from '../pages/settings-page/settings-page.component';
 
 const routes: Routes = [
     {
@@ -26,6 +27,10 @@ const routes: Routes = [
     {
         path: 'server-stats',
         component: ServerStatsPageComponent
+    },
+    {
+        path: 'settings',
+        component: SettingsPageComponent
     },
     { path: '**', pathMatch: 'full', redirectTo: 'home' }
 ];

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -68,6 +68,7 @@ import { UptimeKumaService } from '../services/uptime-kuma-service/uptime-kuma.s
 import { UptimeKumaRepository } from '../services/uptime-kuma-service/uptime-kuma-repository';
 import { WidgetSkeletonComponent } from '../components/widget-skeleton/widget-skeleton.component';
 import { ServerStatsPageComponent } from '../pages/server-stats-page/server-stats-page.component';
+import { SettingsPageComponent } from '../pages/settings-page/settings-page.component';
 import { QBitTorrentDetailsComponent } from '../components/custom-link/custom-details/qbittorrent-details/qbittorrent-details.component';
 import { QBitTorrentService } from '../services/qbittorrent-service/qbittorrent.service';
 import { QBitTorrentRepository } from '../services/qbittorrent-service/qbittorrent.repository';
@@ -81,6 +82,7 @@ import { TautulliRepository } from '../services/tautulli-service/tautulli.reposi
         HomePageComponent,
         FuelPricesPageComponent,
         ServerStatsPageComponent,
+        SettingsPageComponent,
         UrlHealthCheckerComponent,
         CustomLinkComponent,
         PlexDetailsComponent,

--- a/src/components/menu/menu.component.html
+++ b/src/components/menu/menu.component.html
@@ -17,6 +17,9 @@
         <li>
           <a [routerLink]="['/', 'server-stats']" [routerLinkActive]="'active'" (click)="showMenu = !showMenu"><i class="fas fa-chart-line"></i> Server Stats</a>
         </li>
+        <li>
+          <a [routerLink]="['/', 'settings']" [routerLinkActive]="'active'" (click)="showMenu = !showMenu"><i class="fas fa-cog"></i> Settings</a>
+        </li>
       </ul>
     </div>
   }

--- a/src/pages/settings-page/settings-page.component.html
+++ b/src/pages/settings-page/settings-page.component.html
@@ -1,0 +1,55 @@
+<div class="settings-page">
+  <top-info></top-info>
+
+  <main class="container settings-page__content">
+    <section class="settings-page__intro">
+      <div>
+        <p class="eyebrow">Configuration</p>
+        <h1>Settings</h1>
+        <p class="settings-page__description">Manage integration credentials without rebuilding the container. Blank values remove the database override and restore the environment variable fallback.</p>
+      </div>
+      <button class="btn btn-primary" type="button" (click)="saveSettings()" [disabled]="isLoading() || isSaving()">
+        @if (isSaving()) { <i class="fas fa-sync fa-spin"></i> Saving... } @else { <i class="fas fa-save"></i> Save settings }
+      </button>
+    </section>
+
+    @if (isLoading()) {
+      <section class="state-card"><i class="fas fa-circle-notch fa-spin"></i><span>Loading settings...</span></section>
+    }
+
+    @if (hasError()) {
+      <section class="state-card state-card--error"><i class="fas fa-exclamation-triangle"></i><span>Settings could not be loaded or saved. Try again.</span></section>
+    }
+
+    @if (isSaved()) {
+      <p class="settings-page__status"><i class="fas fa-check"></i> Settings saved.</p>
+    }
+
+    @if (!isLoading() && !hasError()) {
+      <section class="settings-grid">
+        @for (setting of settings(); track setting.key) {
+          <article class="setting-card">
+            <div class="setting-card__header">
+              <div>
+                <h2>{{ setting.label }}</h2>
+                <p>{{ setting.description }}</p>
+              </div>
+              @if (setting.isConfigured) { <span class="setting-card__state">Configured</span> } @else { <span class="setting-card__state setting-card__state--empty">Not configured</span> }
+            </div>
+            <label class="setting-card__field">
+              <span>{{ setting.environmentVariable }}</span>
+              <div class="setting-card__input">
+                <input class="form-control" [type]="setting.isSecret && !isSecretVisible(setting.key) ? 'password' : 'text'" [(ngModel)]="setting.value" [attr.aria-label]="setting.label">
+                @if (setting.isSecret) {
+                  <button class="btn btn-outline-secondary" type="button" (click)="toggleSecret(setting.key)" [attr.aria-label]="isSecretVisible(setting.key) ? 'Hide value' : 'Show value'"><i [class]="isSecretVisible(setting.key) ? 'fas fa-eye-slash' : 'fas fa-eye'"></i></button>
+                }
+              </div>
+            </label>
+          </article>
+        }
+      </section>
+    }
+  </main>
+
+  <deploy-info></deploy-info>
+</div>

--- a/src/pages/settings-page/settings-page.component.scss
+++ b/src/pages/settings-page/settings-page.component.scss
@@ -1,0 +1,35 @@
+@import "../../styles/utility/variables";
+
+.settings-page {
+    min-height: 100vh;
+
+    &__content { padding: 32px 16px 48px; }
+    &__intro { display: flex; align-items: flex-end; justify-content: space-between; gap: 24px; margin-bottom: 28px; }
+    &__intro h1 { margin: 4px 0 8px; font-size: 2rem; }
+    &__description { max-width: 680px; margin: 0; color: rgba(255, 255, 255, .55); font-size: .85rem; line-height: 1.6; }
+    &__status { margin: 18px 0; color: $success-color; font-size: .8rem; }
+}
+
+.eyebrow { color: $info-color; text-transform: uppercase; letter-spacing: .16em; font-size: .65rem; font-weight: 700; }
+.settings-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 16px; }
+.setting-card { padding: 18px; border: 1px solid rgba(255, 255, 255, .08); border-radius: $border-radius; background: rgba(0, 0, 0, .22); box-shadow: var(--box-shadow); }
+.setting-card__header { display: flex; justify-content: space-between; gap: 16px; margin-bottom: 18px; }
+.setting-card h2 { margin: 0 0 6px; font-size: .95rem; }
+.setting-card p { margin: 0; color: rgba(255, 255, 255, .4); font-size: .72rem; line-height: 1.5; }
+.setting-card__state { flex: 0 0 auto; color: $success-color; font-size: .62rem; text-transform: uppercase; letter-spacing: .08em; }
+.setting-card__state--empty { color: rgba(255, 255, 255, .35); }
+.setting-card__field > span { display: block; margin-bottom: 6px; color: rgba(255, 255, 255, .35); font-size: .62rem; font-family: monospace; }
+.setting-card__input { display: flex; gap: 8px; }
+.setting-card__input .form-control { min-width: 0; border-color: rgba(255, 255, 255, .12); background: rgba(0, 0, 0, .2); color: #fff; }
+.setting-card__input .btn { flex: 0 0 44px; }
+.state-card { display: flex; justify-content: center; align-items: center; gap: 10px; min-height: 180px; padding: 24px; border: 1px dashed rgba(255, 255, 255, .17); border-radius: $border-radius; color: rgba(255, 255, 255, .55); background: rgba(0, 0, 0, .14); text-align: center; }
+.state-card i { color: $info-color; }
+.state-card--error i { color: $danger-color; }
+
+@media (max-width: $mobile-width) {
+    .settings-page__intro { align-items: stretch; flex-direction: column; }
+    .settings-page__intro .btn { width: 100%; }
+    .settings-grid { grid-template-columns: 1fr; }
+    .setting-card__header { display: block; }
+    .setting-card__state { display: inline-block; margin-top: 12px; }
+}

--- a/src/pages/settings-page/settings-page.component.ts
+++ b/src/pages/settings-page/settings-page.component.ts
@@ -1,0 +1,88 @@
+import { Component, OnDestroy, OnInit, signal, WritableSignal } from '@angular/core';
+import { Subject, takeUntil } from 'rxjs';
+import { ConfigsService } from '../../services/configs-service/configs.service';
+import { ISetting } from '../../services/configs-service/types/setting.type';
+
+@Component({
+    selector: 'settings-page',
+    templateUrl: './settings-page.component.html',
+    styleUrls: ['./settings-page.component.scss'],
+    standalone: false
+})
+export class SettingsPageComponent implements OnInit, OnDestroy {
+
+    public settings: WritableSignal<Array<ISetting>> = signal<Array<ISetting>>([]);
+    public isLoading: WritableSignal<boolean> = signal<boolean>(true);
+    public isSaving: WritableSignal<boolean> = signal<boolean>(false);
+    public hasError: WritableSignal<boolean> = signal<boolean>(false);
+    public isSaved: WritableSignal<boolean> = signal<boolean>(false);
+    public visibleSecrets: WritableSignal<Set<string>> = signal<Set<string>>(new Set<string>());
+
+    private readonly _configsService: ConfigsService;
+    private readonly _destroy: Subject<void> = new Subject();
+
+    constructor(configsService: ConfigsService) {
+        this._configsService = configsService;
+    }
+
+    public ngOnInit(): void {
+        this.loadSettings();
+    }
+
+    public loadSettings(): void {
+        this.isLoading.set(true);
+        this.hasError.set(false);
+
+        this._configsService.getAllSettings()
+            .pipe(takeUntil(this._destroy))
+            .subscribe({
+                next: (settings) => {
+                    this.settings.set(settings);
+                    this.isLoading.set(false);
+                },
+                error: () => {
+                    this.hasError.set(true);
+                    this.isLoading.set(false);
+                }
+            });
+    }
+
+    public saveSettings(): void {
+        this.isSaving.set(true);
+        this.isSaved.set(false);
+        this.hasError.set(false);
+
+        this._configsService.updateSettings(this.settings())
+            .pipe(takeUntil(this._destroy))
+            .subscribe({
+                next: (settings) => {
+                    this.settings.set(settings);
+                    this.isSaving.set(false);
+                    this.isSaved.set(true);
+                },
+                error: () => {
+                    this.hasError.set(true);
+                    this.isSaving.set(false);
+                }
+            });
+    }
+
+    public toggleSecret(key: string): void {
+        const visibleSecrets = new Set(this.visibleSecrets());
+        if (visibleSecrets.has(key)) {
+            visibleSecrets.delete(key);
+        } else {
+            visibleSecrets.add(key);
+        }
+        this.visibleSecrets.set(visibleSecrets);
+    }
+
+    public isSecretVisible(key: string): boolean {
+        return this.visibleSecrets().has(key);
+    }
+
+    public ngOnDestroy(): void {
+        this._destroy.next();
+        this._destroy.complete();
+    }
+}

--- a/src/services/configs-service/configs.mapper.ts
+++ b/src/services/configs-service/configs.mapper.ts
@@ -1,11 +1,23 @@
 import { IConfigs } from './types/configs.type';
-
+import { ISetting } from './types/setting.type';
 export class ConfigsMapper {
 
     public static map(response: any): IConfigs {
         return {
             weatherApiKey: response.WeatherApiKey,
             mapsApiKey: response.MapsApiKey
+        };
+    }
+
+    public static mapSetting(response: any): ISetting {
+        return {
+            key: response.Key,
+            environmentVariable: response.EnvironmentVariable,
+            label: response.Label,
+            description: response.Description,
+            value: response.Value,
+            isSecret: response.IsSecret,
+            isConfigured: response.IsConfigured
         };
     }
 }

--- a/src/services/configs-service/configs.repository.ts
+++ b/src/services/configs-service/configs.repository.ts
@@ -5,6 +5,7 @@ import { ConfigsMapper } from './configs.mapper';
 import { environment } from '../../environments/environment';
 import { mapNetworkError } from '../../core/map-network-error';
 import { IConfigs } from './types/configs.type';
+import { ISetting } from './types/setting.type';
 
 @Injectable()
 export class ConfigsRepository {
@@ -22,6 +23,24 @@ export class ConfigsRepository {
                 map((response: any) => {
                     return ConfigsMapper.map(response);
                 })
+            );
+    }
+
+    public getAllSettings(): Observable<Array<ISetting>> {
+        return this._httpClient.get(`${environment.apiBaseUrl}/api/settings`)
+            .pipe(
+                mapNetworkError(),
+                map((response: any) => response.Settings.map((setting: any) => ConfigsMapper.mapSetting(setting)))
+            );
+    }
+
+    public updateSettings(settings: Array<ISetting>): Observable<Array<ISetting>> {
+        return this._httpClient.put(`${environment.apiBaseUrl}/api/settings`, {
+            Settings: settings.map((setting) => ({ Key: setting.key, Value: setting.value }))
+        })
+            .pipe(
+                mapNetworkError(),
+                map((response: any) => response.Settings.map((setting: any) => ConfigsMapper.mapSetting(setting)))
             );
     }
 }

--- a/src/services/configs-service/configs.service.ts
+++ b/src/services/configs-service/configs.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { IConfigs } from './types/configs.type';
 import { Observable, of, tap } from 'rxjs';
 import { ConfigsRepository } from './configs.repository';
+import { ISetting } from './types/setting.type';
 
 @Injectable()
 export class ConfigsService {
@@ -9,8 +10,8 @@ export class ConfigsService {
     private _configsRepository: ConfigsRepository;
     private _cachedConfigs: { configs: IConfigs; timestamp: Date } | null = null;
 
-    constructor(fuelPriceRepository: ConfigsRepository) {
-        this._configsRepository = fuelPriceRepository;
+    constructor(configsRepository: ConfigsRepository) {
+        this._configsRepository = configsRepository;
     }
 
     public refreshCache(): Observable<IConfigs> {
@@ -40,5 +41,18 @@ export class ConfigsService {
         }
 
         return this.refreshCache();
+    }
+
+    public getAllSettings(): Observable<Array<ISetting>> {
+        return this._configsRepository.getAllSettings();
+    }
+
+    public updateSettings(settings: Array<ISetting>): Observable<Array<ISetting>> {
+        return this._configsRepository.updateSettings(settings).pipe(
+            tap(() => {
+                this._cachedConfigs = null;
+                localStorage.removeItem('cachedConfigs');
+            })
+        );
     }
 }

--- a/src/services/configs-service/types/setting.type.ts
+++ b/src/services/configs-service/types/setting.type.ts
@@ -1,0 +1,9 @@
+export interface ISetting {
+    key: string;
+    environmentVariable: string;
+    label: string;
+    description: string;
+    value: string;
+    isSecret: boolean;
+    isConfigured: boolean;
+}


### PR DESCRIPTION
## Summary
- add a database-backed Settings page for integration credentials and storage configuration
- resolve saved values first and fall back to existing environment variables when no override is set
- add settings migration, API endpoints, navigation, secret visibility controls, and removal of tracked OpenHands memory files

## Validation
- `npm run lint`
- `npm run test-ci` (38 tests passed)
- `npm run build`
- `dotnet build api/home-box-landing/HomeBoxLanding.sln --configuration Release --no-restore`
- `dotnet test api/home-box-landing/HomeBoxLanding.sln --configuration Release --no-restore` (15 tests passed)

Build output contains existing Sass deprecation and bundle-budget warnings.

This pull request was created by an AI agent (OpenHands) on behalf of the user.