### PR TITLE
feat: add fuzzy link search overlay

### DIFF
--- a/src/components/header/header.component.html
+++ b/src/components/header/header.component.html
@@ -9,10 +9,13 @@
           <div class="o-grid o-grid--static">
             <div class="o-grid__col">
               <input class="c-field c-field--small c-field--icon-post" type="text"
-                placeholder="Search the web..." (change)="searchWeb()" [(ngModel)]="webQuery">
+                placeholder="Search links..." role="combobox" aria-controls="search-results"
+                [attr.aria-expanded]="isSearchOpen()" [attr.aria-activedescendant]="selectedResultIndex() >= 0 ? 'search-result-' + selectedResultIndex() : null"
+                (click)="openSearch()" (focus)="openSearch()" (keydown)="handleSearchKeydown($event)"
+                [(ngModel)]="webQuery" (ngModelChange)="updateSearchResults()">
             </div>
             <div class="o-grid__col o-grid__col--fixed">
-              <div class="c-icon c-icon--small c-icon--post"><i class="fab fa-google"></i></div>
+              <div class="c-icon c-icon--small c-icon--post"><i class="fa fa-search"></i></div>
             </div>
           </div>
         </div>
@@ -34,3 +37,37 @@
     </div>
   </div>
 </div>
+
+@if (isSearchOpen()) {
+  <div class="search-overlay" (click)="closeSearch()">
+    <div class="search-dialog" role="dialog" aria-modal="true" aria-label="Search links" (click)="$event.stopPropagation()">
+      <div class="search-dialog__input">
+        <i class="fa fa-search" aria-hidden="true"></i>
+        <input #dialogSearchInput class="c-field" type="text" aria-label="Search links" [(ngModel)]="webQuery"
+               (ngModelChange)="updateSearchResults()" (keydown)="handleSearchKeydown($event)">
+        <button type="button" class="search-dialog__close" aria-label="Close search" (click)="closeSearch()">
+          <i class="fa fa-times" aria-hidden="true"></i>
+        </button>
+      </div>
+
+      <div id="search-results" class="search-results" role="listbox" aria-label="Matching links">
+        @for (result of searchResults(); track result.link!.identifier) {
+          <button #searchResult type="button" class="search-result" role="option"
+                  id="search-result-{{ $index }}" [class.search-result--active]="selectedResultIndex() === $index"
+                  [attr.aria-selected]="selectedResultIndex() === $index"
+                  (click)="openResult(result)" (keydown)="handleResultKeydown($event, $index)">
+            <span class="search-result__name">{{ result.link!.name }}</span>
+            <span class="search-result__context">{{ result.folderName ? result.folderName + ' · ' : '' }}{{ result.columnName }}</span>
+          </button>
+        }
+        <button #searchResult type="button" class="search-result search-result--google" role="option"
+                id="search-result-{{ searchResults().length }}" [class.search-result--active]="selectedResultIndex() === searchResults().length"
+                [attr.aria-selected]="selectedResultIndex() === searchResults().length"
+                (click)="searchWeb()" (keydown)="handleResultKeydown($event, searchResults().length)">
+          <span class="search-result__name"><i class="fab fa-google" aria-hidden="true"></i> Search Google</span>
+          <span class="search-result__context">Search for “{{ webQuery || 'anything' }}”</span>
+        </button>
+      </div>
+    </div>
+  </div>
+}

--- a/src/components/header/header.component.scss
+++ b/src/components/header/header.component.scss
@@ -4,3 +4,115 @@
     background-color: rgba(255, 255, 255, 0.05);
     padding: 15px;
 }
+
+.search-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 1050;
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    padding: 12vh 20px 20px;
+    background: rgba(0, 0, 0, 0.72);
+}
+
+.search-dialog {
+    width: min(680px, 100%);
+    overflow: hidden;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: $border-radius;
+    background: #1e293c;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+
+    &__input {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 12px 16px;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+
+        > i {
+            color: rgba(255, 255, 255, 0.65);
+        }
+
+        .c-field {
+            flex: 1;
+            border: 0;
+            background: transparent;
+            font-size: 1.2rem;
+            padding: 4px 0;
+        }
+    }
+
+    &__close {
+        border: 0;
+        color: rgba(255, 255, 255, 0.65);
+        background: transparent;
+        cursor: pointer;
+
+        &:hover {
+            color: white;
+        }
+    }
+}
+
+.search-results {
+    max-height: min(60vh, 480px);
+    overflow-y: auto;
+    padding: 8px;
+}
+
+.search-result {
+    display: flex;
+    width: 100%;
+    align-items: center;
+    justify-content: space-between;
+    gap: 20px;
+    padding: 12px;
+    border: 0;
+    border-radius: $border-radius;
+    color: white;
+    text-align: left;
+    background: transparent;
+    cursor: pointer;
+
+    &:hover,
+    &:focus,
+    &--active {
+        outline: 0;
+        background: rgba(255, 255, 255, 0.12);
+    }
+
+    &__name {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    &__context {
+        flex-shrink: 0;
+        color: rgba(255, 255, 255, 0.55);
+        font-size: 0.8rem;
+    }
+
+    &--google {
+        margin-top: 8px;
+        border-top: 1px solid rgba(255, 255, 255, 0.15);
+        border-radius: 0;
+    }
+}
+
+@media(max-width: $mobile-width) {
+    .search-overlay {
+        padding: 8vh 12px 12px;
+    }
+
+    .search-result {
+        display: block;
+
+        &__context {
+            display: block;
+            margin-top: 3px;
+        }
+    }
+}

--- a/src/components/header/header.component.ts
+++ b/src/components/header/header.component.ts
@@ -1,7 +1,10 @@
-import { Component, OnDestroy, OnInit, signal, WritableSignal } from '@angular/core';
+import { Component, ElementRef, OnDestroy, OnInit, QueryList, signal, ViewChild, ViewChildren, WritableSignal } from '@angular/core';
 import { Subscription } from 'rxjs';
+import { LinkService } from '../../services/link-service/link.service';
+import { IColumn } from '../../services/link-service/types/column.type';
 import { WebSocketService } from '../../services/websocket-service/web-socket.service';
 import { WebSocketKey } from '../../services/websocket-service/types/web-socket.key';
+import { findLinkSearchResults, ILinkSearchResult } from './link-search';
 
 @Component({
     selector: 'header-component',
@@ -11,18 +14,37 @@ import { WebSocketKey } from '../../services/websocket-service/types/web-socket.
 })
 export class HeaderComponent implements OnInit, OnDestroy {
 
+    @ViewChild('dialogSearchInput')
+    public dialogSearchInput!: ElementRef<HTMLInputElement>;
+
+    @ViewChildren('searchResult')
+    public searchResultElements!: QueryList<ElementRef<HTMLButtonElement>>;
+
     public currentTime: Date = new Date();
     public webQuery: string = '';
     public isConnected: WritableSignal<boolean> = signal<boolean>(false);
+    public isSearchOpen: WritableSignal<boolean> = signal<boolean>(false);
+    public searchResults: WritableSignal<Array<ILinkSearchResult>> = signal<Array<ILinkSearchResult>>([]);
+    public selectedResultIndex: WritableSignal<number> = signal<number>(-1);
 
     private readonly _subscriptions: Subscription = new Subscription();
     private readonly _webSocketService: WebSocketService;
+    private readonly _linkService: LinkService;
+    private _columns: Array<IColumn> = [];
 
-    constructor() {
+    constructor(linkService: LinkService) {
+        this._linkService = linkService;
         this._webSocketService = WebSocketService.instance();
     }
 
     public ngOnInit(): void {
+        this._subscriptions.add(
+            this._linkService.getAllColumns().subscribe((columns) => {
+                this._columns = columns;
+                this.updateSearchResults();
+            })
+        );
+
         this._subscriptions.add(
             this._webSocketService.isConnected
                 .asObservable()
@@ -66,11 +88,114 @@ export class HeaderComponent implements OnInit, OnDestroy {
         return greeting;
     }
 
+    public openSearch(): void {
+        if (this.isSearchOpen()) {
+            return;
+        }
+
+        this.isSearchOpen.set(true);
+        this.updateSearchResults();
+        setTimeout(() => this.dialogSearchInput?.nativeElement.focus());
+    }
+
+    public closeSearch(): void {
+        this.isSearchOpen.set(false);
+        this.selectedResultIndex.set(-1);
+    }
+
+    public updateSearchResults(): void {
+        this.searchResults.set(findLinkSearchResults(this._columns, this.webQuery));
+        this.selectedResultIndex.set(-1);
+    }
+
+    public handleSearchKeydown(event: KeyboardEvent): void {
+        if (event.key === 'Escape') {
+            event.preventDefault();
+            this.closeSearch();
+            return;
+        }
+
+        if (event.key === 'ArrowDown') {
+            event.preventDefault();
+            this.selectResult(0);
+            this.focusSelectedResult();
+            return;
+        }
+
+        if (event.key === 'Enter' && this.selectedResultIndex() >= 0) {
+            event.preventDefault();
+            this.openSelectedResult();
+        }
+    }
+
+    public handleResultKeydown(event: KeyboardEvent, index: number): void {
+        if (event.key === 'ArrowDown') {
+            event.preventDefault();
+            this.selectResult(Math.min(index + 1, this.searchResults().length));
+            this.focusSelectedResult();
+            return;
+        }
+
+        if (event.key === 'ArrowUp') {
+            event.preventDefault();
+            if (index === 0) {
+                this.selectedResultIndex.set(-1);
+                this.dialogSearchInput?.nativeElement.focus();
+                return;
+            }
+            this.selectResult(index - 1);
+            this.focusSelectedResult();
+            return;
+        }
+
+        if (event.key === 'Enter') {
+            event.preventDefault();
+            this.openSelectedResult();
+            return;
+        }
+
+        if (event.key === 'Escape') {
+            event.preventDefault();
+            this.closeSearch();
+        }
+    }
+
+    public selectResult(index: number): void {
+        this.selectedResultIndex.set(index);
+    }
+
+    public openResult(result: ILinkSearchResult): void {
+        if (result.isGoogleSearch) {
+            this.searchWeb();
+            return;
+        }
+
+        if (result.link) {
+            window.location.href = result.link.url;
+        }
+    }
+
     public searchWeb(): void {
-        window.location.href = `https://www.google.com/search?q=${this.webQuery}`;
+        window.location.href = `https://www.google.com/search?q=${encodeURIComponent(this.webQuery)}`;
     }
 
     public ngOnDestroy(): void {
         this._subscriptions.unsubscribe();
+    }
+
+    private openSelectedResult(): void {
+        const index = this.selectedResultIndex();
+        const result = this.searchResults()[index] ?? {
+            link: null,
+            columnName: null,
+            folderName: null,
+            isGoogleSearch: true
+        };
+
+        this.openResult(result);
+    }
+
+    private focusSelectedResult(): void {
+        setTimeout(() => this.searchResultElements.get(this.selectedResultIndex())?.nativeElement.focus());
     }
 }

--- a/src/components/header/link-search.spec.ts
+++ b/src/components/header/link-search.spec.ts
@@ -1,0 +1,61 @@
+import { IColumn } from '../../services/link-service/types/column.type';
+import { ILink } from '../../services/link-service/types/link.type';
+import { findLinkSearchResults, flattenLinks } from './link-search';
+
+function createLink(name: string, sortOrder = 0, folderId: string | null = null): ILink {
+    return {
+        identifier: name,
+        containerName: null,
+        name,
+        url: `https://${name}.example.com`,
+        host: name,
+        port: 443,
+        iconUrl: '',
+        sortOrder,
+        columnId: 'column-1',
+        folderId
+    };
+}
+
+describe('link search', () => {
+    const columns: Array<IColumn> = [{
+        identifier: 'column-1',
+        name: 'Services',
+        icon: 'fa-server',
+        sortOrder: 0,
+        links: [createLink('Plex'), createLink('Pihole', 1)],
+        folders: [{
+            identifier: 'folder-1',
+            name: 'Media',
+            icon: 'fa-folder',
+            sortOrder: 2,
+            columnId: 'column-1',
+            links: [createLink('Radarr', 0, 'folder-1')]
+        }]
+    }];
+
+    it('flattens direct and folder links with their location context', () => {
+        expect(flattenLinks(columns).map((result) => [result.link!.name, result.folderName, result.columnName])).toEqual([
+            ['Plex', null, 'Services'],
+            ['Pihole', null, 'Services'],
+            ['Radarr', 'Media', 'Services']
+        ]);
+    });
+
+    it('returns every link for an empty query', () => {
+        expect(findLinkSearchResults(columns, '').map((result) => result.link!.name)).toEqual(['Plex', 'Pihole', 'Radarr']);
+    });
+
+    it('ranks exact and partial name matches ahead of other matches', () => {
+        expect(findLinkSearchResults(columns, 'pihole').map((result) => result.link!.name)).toEqual(['Pihole']);
+        expect(findLinkSearchResults(columns, 'plex').map((result) => result.link!.name)).toEqual(['Plex']);
+    });
+
+    it('finds a close link when the query contains a spelling mistake', () => {
+        expect(findLinkSearchResults(columns, 'pihol').map((result) => result.link!.name)).toEqual(['Pihole']);
+    });
+
+    it('returns no links when the query is not reasonably close', () => {
+        expect(findLinkSearchResults(columns, 'calendar')).toEqual([]);
+    });
+});

--- a/src/components/header/link-search.ts
+++ b/src/components/header/link-search.ts
@@ -1,0 +1,89 @@
+import { IColumn } from '../../services/link-service/types/column.type';
+import { ColumnItems } from '../../services/link-service/column-items';
+import { IFolder } from '../../services/link-service/types/folder.type';
+import { ILink } from '../../services/link-service/types/link.type';
+
+export interface ILinkSearchResult {
+    link: ILink | null;
+    columnName: string | null;
+    folderName: string | null;
+    isGoogleSearch: boolean;
+}
+
+export function flattenLinks(columns: Array<IColumn>): Array<ILinkSearchResult> {
+    return columns.flatMap((column) => ColumnItems.sort(column).flatMap((item) => {
+        if (item.kind === 'link') {
+            return createResult(item.link, column.name, null);
+        }
+
+        return flattenFolderLinks(column.name, item.folder);
+    }));
+}
+
+export function findLinkSearchResults(columns: Array<IColumn>, query: string): Array<ILinkSearchResult> {
+    const normalizedQuery = normalize(query);
+    const links = flattenLinks(columns);
+
+    if (!normalizedQuery) {
+        return links;
+    }
+
+    return links
+        .map((result) => ({ result, score: scoreResult(result, normalizedQuery) }))
+        .filter(({ score }) => score > 0)
+        .sort((a, b) => b.score - a.score || a.result.link!.name.localeCompare(b.result.link!.name))
+        .map(({ result }) => result);
+}
+
+function flattenFolderLinks(columnName: string, folder: IFolder): Array<ILinkSearchResult> {
+    return folder.links.map((link) => createResult(link, columnName, folder.name));
+}
+
+function createResult(link: ILink, columnName: string, folderName: string | null): ILinkSearchResult {
+    return { link, columnName, folderName, isGoogleSearch: false };
+}
+
+function scoreResult(result: ILinkSearchResult, query: string): number {
+    const name = normalize(result.link!.name);
+    const url = normalize(result.link!.url);
+
+    if (name === query) {
+        return 1000;
+    }
+    if (name.startsWith(query)) {
+        return 800 - (name.length - query.length);
+    }
+    if (name.includes(query)) {
+        return 600 - (name.length - query.length);
+    }
+    if (url.includes(query)) {
+        return 400 - Math.min(url.length - query.length, 300);
+    }
+
+    const distance = levenshteinDistance(name, query);
+    const threshold = Math.max(2, Math.floor(name.length / 3));
+    return distance <= threshold ? 200 - distance : 0;
+}
+
+function normalize(value: string): string {
+    return value.trim().toLocaleLowerCase();
+}
+
+function levenshteinDistance(left: string, right: string): number {
+    const previous = Array.from({ length: right.length + 1 }, (value, index) => index);
+
+    for (let leftIndex = 1; leftIndex <= left.length; leftIndex++) {
+        let diagonal = previous[0];
+        previous[0] = leftIndex;
+
+        for (let rightIndex = 1; rightIndex <= right.length; rightIndex++) {
+            const above = previous[rightIndex];
+            previous[rightIndex] = left[leftIndex - 1] === right[rightIndex - 1]
+                ? diagonal
+                : Math.min(previous[rightIndex - 1], above, diagonal) + 1;
+            diagonal = above;
+        }
+    }
+
+    return previous[right.length];
+}


### PR DESCRIPTION
## Summary
- Replace the header web-search input with a link-search launcher.
- Add a centered modal overlay with live matching links, column/folder context, responsive styling, and a persistent Google search fallback.
- Support exact, partial, URL, and typo-tolerant fuzzy matching plus keyboard navigation and Enter-to-open behavior.
- Add focused matcher tests.

## Validation
- `npm run lint`
- `npm run test-ci` (43 tests passed)
- `npm run build` (passes with existing Sass and bundle-size warnings)

This pull request was created by an AI agent (OpenHands) on behalf of the user.