### PR TITLE
feat: show logos in search results

### DIFF
--- a/src/components/header/header.component.html
+++ b/src/components/header/header.component.html
@@ -56,7 +56,11 @@
                   id="search-result-{{ $index }}" [class.search-result--active]="selectedResultIndex() === $index"
                   [attr.aria-selected]="selectedResultIndex() === $index"
                   (click)="openResult(result)" (keydown)="handleResultKeydown($event, $index)">
-            <span class="search-result__name">{{ result.link!.name }}</span>
+            <span class="search-result__link">
+              <img class="search-result__logo" [src]="result.link!.iconUrl || './assets/apps/default.png'"
+                   alt="{{ result.link!.name }} logo" (error)="handleSearchIconError($event, result)">
+              <span class="search-result__name">{{ result.link!.name }}</span>
+            </span>
             <span class="search-result__context">{{ result.folderName ? result.folderName + ' · ' : '' }}{{ result.columnName }}</span>
           </button>
         }

--- a/src/components/header/header.component.scss
+++ b/src/components/header/header.component.scss
@@ -83,6 +83,21 @@
         background: rgba(255, 255, 255, 0.12);
     }
 
+    &__link {
+        display: flex;
+        min-width: 0;
+        align-items: center;
+        gap: 10px;
+    }
+
+    &__logo {
+        width: 28px;
+        height: 28px;
+        flex-shrink: 0;
+        border-radius: 4px;
+        object-fit: contain;
+    }
+
     &__name {
         overflow: hidden;
         text-overflow: ellipsis;

--- a/src/components/header/header.component.ts
+++ b/src/components/header/header.component.ts
@@ -175,6 +175,22 @@ export class HeaderComponent implements OnInit, OnDestroy {
         }
     }
 
+    public handleSearchIconError(event: Event, result: ILinkSearchResult): void {
+        if (!result.link) {
+            return;
+        }
+
+        const image = event.target as HTMLImageElement;
+        if (result.link.iconUrl.indexOf('https://cdn.jsdelivr.net/') === -1) {
+            result.link.iconUrl = `https://cdn.jsdelivr.net/gh/selfhst/icons/png/${result.link.name.replace(/\s+/g, '-').toLowerCase()}.png`;
+            image.src = result.link.iconUrl;
+            return;
+        }
+
+        result.link.iconUrl = './assets/apps/default.png';
+        image.src = result.link.iconUrl;
+    }
+
     public searchWeb(): void {
         window.location.href = `https://www.google.com/search?q=${encodeURIComponent(this.webQuery)}`;
     }


### PR DESCRIPTION
## Summary
- Display each link's configured logo beside its name in search results.
- Preserve the existing selfhst CDN fallback and default app logo behavior when an image fails.
- Keep logos accessible with link-specific alt text and responsive sizing.

## Validation
- `npm run lint`
- `npm run test-ci` (44 tests passed)
- `npm run build` (passes with existing Sass and bundle-size warnings)

This pull request was created by an AI agent (OpenHands) on behalf of the user.