### PR TITLE
fix: float mobile search beside menu

### DIFF
--- a/src/components/header/header.component.html
+++ b/src/components/header/header.component.html
@@ -5,7 +5,7 @@
         <i class="fa fa-home"></i> {{ getGreeting() }}, please enjoy your stay.
       </div>
       <div class="o-grid__col">
-        <div class="c-input-group mx-3 u-mt-2 u-mb-2 desktop--no-my">
+        <div class="header-component__search c-input-group mx-3 u-mt-2 u-mb-2 desktop--no-my">
           <div class="o-grid o-grid--static">
             <div class="o-grid__col">
               <input class="c-field c-field--small c-field--icon-post" type="text"

--- a/src/components/header/header.component.scss
+++ b/src/components/header/header.component.scss
@@ -3,6 +3,38 @@
 .header-component {
     background-color: rgba(255, 255, 255, 0.05);
     padding: 15px;
+
+    &__search {
+        @media(max-width: $mobile-width) {
+            position: fixed;
+            right: 25px;
+            bottom: calc(25px + env(safe-area-inset-bottom));
+            left: 85px;
+            z-index: 1000;
+            margin: 0 !important;
+
+            .o-grid {
+                height: 50px;
+            }
+
+            .c-field,
+            .c-icon {
+                height: 50px;
+            }
+
+            .c-field {
+                padding: 10px 12px;
+                font-size: 0.9rem;
+            }
+
+            .c-icon {
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                padding: 0;
+            }
+        }
+    }
 }
 
 .search-overlay {


### PR DESCRIPTION
## Summary

- Float the search box beside the fixed menu button on mobile screens.
- Match the search control to the menu button height for easier one-handed use.
- Preserve the existing desktop header layout and support mobile safe-area insets.

## Validation

- `npm run lint`
- `npm run build`
- `npm run test-ci` (44 tests passed)
- `git diff --check`

Build output contains only existing Sass deprecation and bundle-budget warnings.

This pull request was created by an AI agent (OpenHands) on behalf of the user.